### PR TITLE
feat(alertmanager): link alertmanager to pushover for notifications

### DIFF
--- a/apps/monitoring-system/kube-prometheus-stack/app/alertmanager-config.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/alertmanager-config.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/monitoring.coreos.com/alertmanagerconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: alertmanager
+spec:
+  route:
+    receiver: pushover
+    groupBy: [alertname, namespace]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 12h
+
+  receivers:
+    - name: pushover
+      pushoverConfigs:
+        - userKey:
+            name: alertmanager-pushover-secret
+            key: user-key
+          token:
+            name: alertmanager-pushover-secret
+            key: token
+          title: '{{ template "pushover.default.title" . }}'
+          message: '{{ template "pushover.default.message" . }}'
+          url: '{{ template "pushover.default.url" . }}'
+          priority: '{{ if eq .Status "firing" }}1{{ else }}0{{ end }}'
+          sound: gamelan
+          retry: 60s
+          expire: 1h

--- a/apps/monitoring-system/kube-prometheus-stack/app/external-secret.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/external-secret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-pushover-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: alertmanager-pushover-secret
+    creationPolicy: Owner
+
+  data:
+    - secretKey: user-key
+      remoteRef:
+        key: Pushover
+        property: user_key
+    - secretKey: token
+      remoteRef:
+        key: Pushover
+        property: token

--- a/apps/monitoring-system/kube-prometheus-stack/app/external-secret.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/external-secret.yaml
@@ -18,9 +18,9 @@ spec:
   data:
     - secretKey: user-key
       remoteRef:
-        key: Pushover
+        key: AlertManager - Pushover
         property: user_key
     - secretKey: token
       remoteRef:
-        key: Pushover
+        key: AlertManager - Pushover
         property: token

--- a/apps/monitoring-system/kube-prometheus-stack/app/helm-release.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/helm-release.yaml
@@ -28,7 +28,7 @@ spec:
               namespace: network-system
 
       alertmanagerSpec:
-        # alertmanagerConfiguration: {name: alertmanager}
+        alertmanagerConfiguration: {name: alertmanager}
         # =======================================
         # App Settings
         # =======================================

--- a/apps/monitoring-system/kube-prometheus-stack/app/kustomization.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
+  - ./external-secret.yaml
+  - ./alertmanager-config.yaml
 
   - ./grafana-dashboards.yaml
   - ./external-endpoints


### PR DESCRIPTION
## Summary

- Add `AlertmanagerConfig` resource with a Pushover receiver and routing rules
- Add `ExternalSecret` to pull Pushover credentials (`user_key`, `token`) from 1Password
- Enable `alertmanagerConfiguration` reference in the kube-prometheus-stack HelmRelease

Closes #491