### PR TITLE
feat(monitoring): deploy nvidia dcgm exporter

### DIFF
--- a/apps/monitoring-system/kustomization.yaml
+++ b/apps/monitoring-system/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - ./kube-state-metrics
   - ./mikrotik-exporter
   - ./node-exporter
+  - ./nvidia-dcgm-exporter
   - ./zfs-exporter

--- a/apps/monitoring-system/nvidia-dcgm-exporter/app.ks.yaml
+++ b/apps/monitoring-system/nvidia-dcgm-exporter/app.ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: nvidia-dcgm-exporter
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  targetNamespace: monitoring-system
+
+  path: ./apps/monitoring-system/nvidia-dcgm-exporter/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute: {}

--- a/apps/monitoring-system/nvidia-dcgm-exporter/app/grafana-dashboard.yaml
+++ b/apps/monitoring-system/nvidia-dcgm-exporter/app/grafana-dashboard.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: nvidia-dcgm-exporter
+spec:
+  grafanaCom:
+    id: 12239
+    revision: 2
+
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana

--- a/apps/monitoring-system/nvidia-dcgm-exporter/app/helm-release.yaml
+++ b/apps/monitoring-system/nvidia-dcgm-exporter/app/helm-release.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nvidia-dcgm-exporter
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: dcgm-exporter
+      version: 4.8.1
+      sourceRef:
+        kind: HelmRepository
+        name: dcgm-exporter
+
+  values:
+    runtimeClassName: nvidia
+
+    nodeSelector:
+      nvidia.com/gpu.present: "true"
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+    serviceMonitor:
+      enabled: true

--- a/apps/monitoring-system/nvidia-dcgm-exporter/app/helm-repository.yaml
+++ b/apps/monitoring-system/nvidia-dcgm-exporter/app/helm-repository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: dcgm-exporter
+spec:
+  interval: 1h
+  url: https://nvidia.github.io/dcgm-exporter/helm-charts

--- a/apps/monitoring-system/nvidia-dcgm-exporter/app/kustomization.yaml
+++ b/apps/monitoring-system/nvidia-dcgm-exporter/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - helm-repository.yaml
+  - helm-release.yaml
+  - grafana-dashboard.yaml

--- a/apps/monitoring-system/nvidia-dcgm-exporter/kustomization.yaml
+++ b/apps/monitoring-system/nvidia-dcgm-exporter/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml


### PR DESCRIPTION
Closes #530

## Changes

- Deploy `nvidia/dcgm-exporter` v4.8.1 as a DaemonSet in `monitoring-system`
- Scoped to GPU nodes via `nodeSelector: nvidia.com/gpu.present: "true"`
- `runtimeClassName: nvidia` to use the existing NVIDIA container runtime
- ServiceMonitor enabled for Prometheus scraping
- Grafana dashboard (ID 12239 — NVIDIA DCGM Exporter Dashboard)