### PR TITLE
fix(monitoring): route InfoInhibitor to null and add inhibit rules

### DIFF
--- a/apps/monitoring-system/kube-prometheus-stack/app/alertmanager-config.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/alertmanager-config.yaml
@@ -27,7 +27,22 @@ spec:
       - receiver: 'null'
         matchers:
           - name: alertname
+            value: InfoInhibitor
+
+      - receiver: 'null'
+        matchers:
+          - name: alertname
             value: Watchdog
+
+  inhibitRules:
+    - sourceMatch:
+        - name: alertname
+          value: InfoInhibitor
+      targetMatch:
+        - name: severity
+          value: info
+      equal:
+        - namespace
 
   receivers:
     - name: 'null'


### PR DESCRIPTION
Route the InfoInhibitor alert to the null receiver so it no longer triggers Pushover notifications. Also add inhibitRules to properlysuppress severity=info alerts per namespace when InfoInhibitor fires.