### PR TITLE
feat(bambuddy): migrate slicer from orca-slicer to bambu-studio

### DIFF
--- a/apps/home-automation/bambuddy/app/helm-release.yaml
+++ b/apps/home-automation/bambuddy/app/helm-release.yaml
@@ -144,7 +144,7 @@ spec:
           slicer:
             app:
               - path: /app/data
-                subPath: slicer-data
+                subPath: bambu-studio-data
 
       tmpfs:
         type: emptyDir

--- a/apps/home-automation/bambuddy/app/helm-release.yaml
+++ b/apps/home-automation/bambuddy/app/helm-release.yaml
@@ -83,8 +83,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/mirceanton/orca-slicer-api
-              tag: 2.3.2
+              repository: ghcr.io/mirceanton/bambu-studio-api
+              tag: 02.06.00.51
             env:
               PORT: &slicerPort 3000
               NODE_ENV: production


### PR DESCRIPTION
Switch the slicer sidecar from ghcr.io/mirceanton/orca-slicer-api to ghcr.io/mirceanton/bambu-studio-api for better compatibility with Maker World 3MF files.