### PR TITLE
refactor(finances): remove Firefly data importer

### DIFF
--- a/apps/finances/firefly/app/external-secret.yaml
+++ b/apps/finances/firefly/app/external-secret.yaml
@@ -18,35 +18,3 @@ spec:
       remoteRef:
         key: Firefly Keys
         property: STATIC_CRON_TOKEN
-
----
-# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: &name firefly-data-importer-token
-spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword
-  target:
-    name: *name
-  data:
-    - secretKey: ACCESS_TOKEN
-      remoteRef:
-        key: Firefly Data Importer
-        property: ACCESS_TOKEN
-    - secretKey: FIREFLY_III_ACCESS_TOKEN
-      remoteRef:
-        key: Firefly Data Importer
-        property: IMPORTER_TOKEN
-
-    # Enable Banking Integration
-    - secretKey: ENABLE_BANKING_APP_ID
-      remoteRef:
-        key: Firefly Data Importer
-        property: APP_CLIENT_ID
-    - secretKey: ENABLE_BANKING_PRIVATE_KEY
-      remoteRef:
-        key: Firefly Data Importer
-        property: APP_PRIVATE_KEY

--- a/apps/finances/firefly/app/firefly.helm-release.yaml
+++ b/apps/finances/firefly/app/firefly.helm-release.yaml
@@ -121,42 +121,12 @@ spec:
               limits:
                 memory: 64Mi
 
-      data-importer:
-        containers:
-          main:
-            image:
-              repository: fireflyiii/data-importer
-              tag: version-2.3.2
-            envFrom:
-              - configMapRef: { name: firefly-settings }
-              - secretRef: { name: firefly-data-importer-token }
-            env:
-              FIREFLY_III_URL: "http://firefly.finances.svc.cluster.local:8080"
-              VANITY_URL: "https://firefly.home.mirceanton.com"
-
-            probes:
-              liveness: { enabled: true }
-              readiness: { enabled: true }
-
-            resources:
-              requests:
-                cpu: 20m
-                memory: 64Mi
-              limits:
-                memory: 1Gi
-
     service:
       firefly:
         controller: firefly
         ports:
           http:
             port: 8080
-      data-importer:
-        controller: data-importer
-        ports:
-          http:
-            port: 8080
-
     route:
       home:
         hostnames: ["firefly.home.mirceanton.com"]
@@ -167,16 +137,6 @@ spec:
           - backendRefs:
               - name: firefly
                 port: 8080
-      importer:
-        hostnames: ["firefly-importer.home.mirceanton.com"]
-        parentRefs:
-          - name: envoy-internal
-            namespace: network-system
-        rules:
-          - backendRefs:
-              - name: firefly-data-importer
-                port: 8080
-
     persistence:
       data:
         existingClaim: ${APP}
@@ -187,7 +147,3 @@ spec:
                 path: /var/www/html/storage
               - subPath: upload
                 path: /var/www/html/storage/upload
-          data-importer:
-            main:
-              - subPath: importer
-                path: /var/www/html/storage/uploads


### PR DESCRIPTION
## Summary

- Removes the Firefly data importer controller, service, HTTPRoute (`firefly-importer.home.mirceanton.com`), persistence mounts, and `firefly-data-importer-token` ExternalSecret

## Test plan

- [ ] Flux reconciles the `firefly` HelmRelease without errors
- [ ] No `firefly-data-importer` pod or service remains in the `finances` namespace