### PR TITLE
feat(llmkube): add ServiceMonitor for model inference services

### DIFF
--- a/apps/ai/llmkube/models/kustomization.yaml
+++ b/apps/ai/llmkube/models/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ./servicemonitor.yaml
   - ./qwen-35b.yaml
   - ./gemma-4-26B-A4B.yaml
   - ./qwen3-0.6b.yaml

--- a/apps/ai/llmkube/models/servicemonitor.yaml
+++ b/apps/ai/llmkube/models/servicemonitor.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: llmkube-models
+spec:
+  selector:
+    matchExpressions:
+      - key: inference.llmkube.dev/service
+        operator: Exists
+  namespaceSelector:
+    matchNames:
+      - ai
+  endpoints:
+    - port: http
+      path: /metrics
+  fallbackScrapeProtocol: PrometheusText0.0.4


### PR DESCRIPTION
## Summary

- Adds a single `ServiceMonitor` that dynamically discovers all LLMKube model services via the `inference.llmkube.dev/service` label selector
- Prometheus will auto-attach the `service` label (= model name) to all scraped metrics, enabling per-model filtering in Grafana

Closes #649