### PR TITLE
feat(ai): deploy GitHub MCP server

### DIFF
--- a/apps/ai/github-mcp/app.ks.yaml
+++ b/apps/ai/github-mcp/app.ks.yaml
@@ -3,17 +3,15 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app litellm
+  name: &app github-mcp
 spec:
   interval: 10m
   prune: true
   wait: true
-  timeout: 15m
+  timeout: 5m
   targetNamespace: ai
 
-  path: ./apps/ai/litellm/app
-  components:
-    - ../../../../components/cnpg/
+  path: ./apps/ai/github-mcp/app
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -22,13 +20,3 @@ spec:
   postBuild:
     substitute:
       APP: *app
-
-  dependsOn:
-    - name: 1password-connect
-      namespace: security-system
-    - name: cloudnative-pg-operator
-      namespace: database-system
-    - name: external-secrets-operator
-      namespace: security-system
-    - name: llmkube
-      namespace: ai

--- a/apps/ai/github-mcp/app/helm-release.yaml
+++ b/apps/ai/github-mcp/app/helm-release.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: github-mcp
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: github-mcp
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      github-mcp:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/github/github-mcp-server
+              tag: v1.3.0@sha256:5c83359327a0bacc3d34db730bea6557d39d341cee0bf6c58c9a896e33150e80
+            args: ["http"]
+
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8082
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8082
+                  failureThreshold: 30
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: github-mcp
+        ports:
+          http:
+            port: 8082
+
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/apps/ai/github-mcp/app/kustomization.yaml
+++ b/apps/ai/github-mcp/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml

--- a/apps/ai/github-mcp/app/oci-repository.yaml
+++ b/apps/ai/github-mcp/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: github-mcp
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/ai/github-mcp/kustomization.yaml
+++ b/apps/ai/github-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/ai/kustomization.yaml
+++ b/apps/ai/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: ai
 resources:
   - ./namespace.yaml
   - ./grafana-folder.yaml
+  - ./github-mcp
   - ./hermes
   - ./kubesearch-mcp
   - ./librechat

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -34,6 +34,11 @@ model_list:
       mode: embedding
 
 mcp_servers:
+  github:
+    url: "http://github-mcp.ai.svc.cluster.local:8082/mcp"
+    auth_type: bearer_token
+    auth_value: os.environ/GITHUB_MCP_TOKEN
+
   kubesearch:
     url: "http://kubesearch-mcp.ai.svc.cluster.local:3000/mcp"
 

--- a/apps/ai/litellm/app/github-mcp-token.yaml
+++ b/apps/ai/litellm/app/github-mcp-token.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/generators.external-secrets.io/githubaccesstoken_v1alpha1.json
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: GithubAccessToken
+metadata:
+  name: mr-borboto-auth-token
+spec:
+  appID: "900136"
+  installID: "53131225"
+  auth:
+    privateKey:
+      secretRef:
+        name: mr-borboto-pem
+        key: private_key_pem
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name litellm-github-mcp-token
+spec:
+  refreshInterval: 55m
+  target:
+    name: *name
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        GITHUB_MCP_TOKEN: "{{ .token }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: GithubAccessToken
+          name: mr-borboto-auth-token

--- a/apps/ai/litellm/app/helm-release.yaml
+++ b/apps/ai/litellm/app/helm-release.yaml
@@ -57,6 +57,12 @@ spec:
                     name: litellm-postgres-app
                     key: uri
 
+              GITHUB_MCP_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-github-mcp-token
+                    key: GITHUB_MCP_TOKEN
+
             resources:
               requests:
                 cpu: 10m

--- a/apps/ai/litellm/app/kustomization.yaml
+++ b/apps/ai/litellm/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   - ./external-secret.yaml
+  - ./github-mcp-token.yaml
   - ./grafana-dashboard.yaml
   - ./helm-release.yaml
   - ./oci-repository.yaml


### PR DESCRIPTION
## Summary
- Self-host the official `github/github-mcp-server` over streamable HTTP in `apps/ai/github-mcp/`, mirroring the `kubesearch-mcp` app layout.
- Register it in LiteLLM's `mcp_servers` config so models get repo/issue/PR/Actions context for this repo.

## Auth design note
Upstream's HTTP transport (`github-mcp-server http`) does **not** read `GITHUB_PERSONAL_ACCESS_TOKEN` from the environment — that only applies to `stdio` mode. In HTTP mode, every request must carry its own `Authorization: Bearer <token>` header (verified by reading `cmd/github-mcp-server/main.go`, `pkg/http/server.go`, and `pkg/http/middleware/token.go` upstream). So instead of wiring the token into the `github-mcp` pod itself, the `mr-borboto` GitHub App installation token is minted by an `ExternalSecret`/`GithubAccessToken` generator in `apps/ai/litellm/app/github-mcp-token.yaml` and injected into the LiteLLM container as `GITHUB_MCP_TOKEN`. LiteLLM's `github` MCP entry uses `auth_type: bearer_token` / `auth_value: os.environ/GITHUB_MCP_TOKEN` to send it on every request. `github-mcp` itself stays auth-free and stateless.

Token rotation: the `ExternalSecret` refreshes every 55m and LiteLLM's `reloader.stakater.com/auto: "true"` annotation restarts the pod on secret change.

## Test plan
- [x] `kustomize build` on `apps/ai/github-mcp/app`, `apps/ai/github-mcp`, `apps/ai/litellm/app`, and `apps/ai` all render cleanly.
- [x] `task lint:prettier -- --check` passes.
- [x] Deployed rendered manifests + a temporary `GithubAccessToken`/`ExternalSecret` into a scratch `testing` namespace; pod came up healthy.
- [x] Confirmed `POST /mcp` without `Authorization` returns `401` with a `WWW-Authenticate` challenge.
- [x] Completed the MCP `initialize` handshake with a real installation token and listed 43 tools.
- [x] Called `search_repositories` with `org:mirceanton` and got back real results (29 repos, including `home-ops`).
- [x] Deleted the `testing` namespace and all scratch resources afterward.

Closes #651