### PR TITLE
feat(finances): swap firefly-mcp image to mcp-server-firefly-iii

### DIFF
--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -56,7 +56,8 @@ mcp_servers:
     url: "http://navidrome-mcp.media.svc.cluster.local:3000/mcp"
 
   firefly:
-    url: "http://firefly-mcp.finances.svc.cluster.local:3000/mcp"
+    url: "http://firefly-mcp.finances.svc.cluster.local:3000/sse"
+    transport: sse
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/finances/firefly/mcp/helm-release.yaml
+++ b/apps/finances/firefly/mcp/helm-release.yaml
@@ -21,12 +21,12 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/radcod3/lampyrid
-              tag: 0.4.0
+              repository: ghcr.io/fabianonetto/mcp-server-firefly-iii
+              tag: main@sha256:46dce54fdca3f0b919052bad9bf04a17fb0d4deed63ee5a871eca1d3bbbf516a
 
             env:
-              FIREFLY_BASE_URL: "http://firefly.finances.svc.cluster.local:8080"
-              MCP_TRANSPORT: "http"
+              FIREFLY_URL: "http://firefly.finances.svc.cluster.local:8080"
+              PORT: "3000"
               FIREFLY_TOKEN:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## Summary
- Swap the `firefly-mcp` image from `ghcr.io/radcod3/lampyrid:0.4.0` to `ghcr.io/fabianonetto/mcp-server-firefly-iii` (pinned to the `main` tag's digest — upstream has no semver releases yet, only `main` + per-commit sha tags).
- Update env vars to match the new server: `FIREFLY_BASE_URL` → `FIREFLY_URL`, drop `MCP_TRANSPORT` (unused by this server), add `PORT: "3000"` to enable its HTTP/SSE listener (otherwise it runs in stdio mode).
- Update the `firefly` MCP entry in litellm's `config.yaml`: this server speaks legacy SSE (`/sse` + `/messages`), not streamable-HTTP `/mcp`, so the URL and `transport: sse` were updated to match (same pattern already used for the `grafana` entry).

## Test plan
- [x] Deployed the new image to a scratch `firefly-mcp-test` namespace (Deployment + Service + a copy of the real `FIREFLY_TOKEN` secret), applied via the flux MCP tool.
- [x] Pod reached `Running`/`1/1 Ready` with no restarts.
- [x] Port-forwarded to the pod and called `POST /api/get_about` — got a valid response from the real Firefly III instance (version 6.6.3), confirming `FIREFLY_URL`/`FIREFLY_TOKEN` wiring works.
- [x] Verified `GET /sse` returns `text/event-stream` with a proper MCP session handshake (`event: endpoint` / `data: /messages?sessionId=...`), confirming the litellm `transport: sse` config will work.
- [x] Cleaned up all scratch test resources (namespace deleted).