### PR TITLE
Revert firefly-mcp image swap to mcp-server-firefly-iii

### DIFF
--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -56,8 +56,7 @@ mcp_servers:
     url: "http://navidrome-mcp.media.svc.cluster.local:3000/mcp"
 
   firefly:
-    url: "http://firefly-mcp.finances.svc.cluster.local:3000/sse"
-    transport: sse
+    url: "http://firefly-mcp.finances.svc.cluster.local:3000/mcp"
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/finances/firefly/mcp/helm-release.yaml
+++ b/apps/finances/firefly/mcp/helm-release.yaml
@@ -21,12 +21,12 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/fabianonetto/mcp-server-firefly-iii
-              tag: main@sha256:46dce54fdca3f0b919052bad9bf04a17fb0d4deed63ee5a871eca1d3bbbf516a
+              repository: ghcr.io/radcod3/lampyrid
+              tag: 0.4.0
 
             env:
-              FIREFLY_URL: "http://firefly.finances.svc.cluster.local:8080"
-              PORT: "3000"
+              FIREFLY_BASE_URL: "http://firefly.finances.svc.cluster.local:8080"
+              MCP_TRANSPORT: "http"
               FIREFLY_TOKEN:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## Summary
Reverts #653. The new image (`ghcr.io/fabianonetto/mcp-server-firefly-iii`) has a real bug in its SSE mode: it keeps one shared `mcpServer`/`transport` global and throws `Error: Already connected to a transport` when a second `GET /sse` arrives before the previous one is torn down. LiteLLM re-lists tools from every configured MCP backend on essentially every proxied request, which triggers this reliably — confirmed via pod logs showing the stack trace, while LiteLLM's logs showed repeated `Successfully fetched 0 tools from server firefly` / `500 Internal Server Error` for `.../sse`.

Filed upstream: fabianonetto/mcp-server-firefly-iii#15

Reverts back to `ghcr.io/radcod3/lampyrid:0.4.0` (streamable HTTP `/mcp`, `FIREFLY_BASE_URL`/`MCP_TRANSPORT` env vars) and the litellm `firefly` MCP entry back to the `/mcp` URL without `transport: sse`.

## Test plan
- [x] Deployed the reverted config (lampyrid image + old env vars) to a scratch `firefly-mcp-test` namespace via the flux MCP tool.
- [x] Pod reached `Running`/`1/1 Ready`.
- [x] Port-forwarded and called `POST /mcp` (`initialize`) — got a valid MCP response.
- [x] Fired 5 concurrent `POST /mcp` requests to simulate LiteLLM's per-request tool refresh — all returned `200`, confirming this image handles concurrent sessions correctly (unlike the reverted image).
- [x] Cleaned up all scratch test resources.