### PR TITLE
feat(finances): swap firefly-mcp image to daften/fireflyiii-mcp

### DIFF
--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -56,7 +56,9 @@ mcp_servers:
     url: "http://navidrome-mcp.media.svc.cluster.local:3000/mcp"
 
   firefly:
-    url: "http://firefly-mcp.finances.svc.cluster.local:3000/mcp"
+    url: "http://firefly-mcp.finances.svc.cluster.local:3000"
+    auth_type: bearer_token
+    auth_value: os.environ/FIREFLY_MCP_TOKEN
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/ai/litellm/app/firefly-mcp-token.yaml
+++ b/apps/ai/litellm/app/firefly-mcp-token.yaml
@@ -3,7 +3,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &name firefly-mcp-secret
+  name: &name litellm-firefly-mcp-token
 spec:
   refreshInterval: 1h
 
@@ -16,7 +16,7 @@ spec:
     creationPolicy: Owner
 
   data:
-    - secretKey: FIREFLY_TOKEN
+    - secretKey: FIREFLY_MCP_TOKEN
       remoteRef:
         key: "Firefly MCP"
         property: token

--- a/apps/ai/litellm/app/helm-release.yaml
+++ b/apps/ai/litellm/app/helm-release.yaml
@@ -63,6 +63,12 @@ spec:
                     name: litellm-github-mcp-token
                     key: GITHUB_MCP_TOKEN
 
+              FIREFLY_MCP_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-firefly-mcp-token
+                    key: FIREFLY_MCP_TOKEN
+
             resources:
               requests:
                 cpu: 10m

--- a/apps/ai/litellm/app/kustomization.yaml
+++ b/apps/ai/litellm/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   - ./external-secret.yaml
+  - ./firefly-mcp-token.yaml
   - ./github-mcp-token.yaml
   - ./grafana-dashboard.yaml
   - ./helm-release.yaml

--- a/apps/finances/firefly/mcp/helm-release.yaml
+++ b/apps/finances/firefly/mcp/helm-release.yaml
@@ -21,17 +21,18 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/radcod3/lampyrid
-              tag: 0.4.0
+              repository: ghcr.io/daften/fireflyiii-mcp
+              tag: 0.2.2@sha256:a08caf45e9030fea7e2429a10265f0579b4ff2403cda431a85e53f181f9b1acb
 
             env:
-              FIREFLY_BASE_URL: "http://firefly.finances.svc.cluster.local:8080"
-              MCP_TRANSPORT: "http"
-              FIREFLY_TOKEN:
-                valueFrom:
-                  secretKeyRef:
-                    name: firefly-mcp-secret
-                    key: FIREFLY_TOKEN
+              FIREFLY_URL: "http://firefly.finances.svc.cluster.local:8080"
+              # Public OAuth client (no secret) registered solely to satisfy this
+              # image's startup check. The actual credential is a PAT, forwarded
+              # by litellm as a Bearer token — the OAuth flow is never exercised.
+              # Remove once daften/fireflyiii-mcp ships native PAT-only HTTP mode
+              # (https://github.com/daften/fireflyiii-mcp/pull/30).
+              FIREFLY_OAUTH_CLIENT_ID: "019ed106-79b5-7361-8613-765e72e38098"
+              MCP_BASE_URL: "http://firefly-mcp.finances.svc.cluster.local:3000"
 
             probes:
               liveness: &probe

--- a/apps/finances/firefly/mcp/kustomization.yaml
+++ b/apps/finances/firefly/mcp/kustomization.yaml
@@ -3,6 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./external-secret.yaml
   - ./helm-release.yaml
   - ./oci-repository.yaml


### PR DESCRIPTION
## Summary
- Swap the `firefly-mcp` image from `ghcr.io/radcod3/lampyrid:0.4.0` to `ghcr.io/daften/fireflyiii-mcp:0.2.2` — actively maintained, proper semver releases, 140 tools.
- This image's HTTP mode requires `FIREFLY_OAUTH_CLIENT_ID` just to start (even though it only matters for the interactive OAuth flow). Configured a throwaway **public** OAuth client (`019ed106-79b5-7361-8613-765e72e38098`, "keep a secret" unchecked, so it's not sensitive) purely to satisfy that startup check — the OAuth flow itself is never exercised.
- The real credential is the Firefly PAT, sent by litellm as a Bearer token on every request. This server forwards whatever Bearer token it receives straight to Firefly III's API, so a PAT works exactly like an OAuth access token would, with zero code on their side caring which.
- Filed an upstream PR (daften/fireflyiii-mcp#30) adding native PAT-only HTTP mode (no OAuth client needed at all). Once merged and released, drop `FIREFLY_OAUTH_CLIENT_ID`/`MCP_BASE_URL` and bump the image.
- Moved the Firefly PAT wiring from the `firefly-mcp` pod (this image doesn't use `FIREFLY_TOKEN` in HTTP mode at all) to litellm's pod instead, since litellm is now the one attaching it as `Authorization: Bearer`. Removed the now-unused `apps/finances/firefly/mcp/external-secret.yaml`, added `apps/ai/litellm/app/firefly-mcp-token.yaml` pulling the same 1Password item into the `ai` namespace as `FIREFLY_MCP_TOKEN`, matching the existing `GITHUB_MCP_TOKEN` pattern.
- Updated litellm's `firefly` MCP entry: this server serves MCP traffic at the root path (not `/mcp`), confirmed by reading the published `v0.2.2` source — so the URL has no path suffix, with `auth_type: bearer_token` / `auth_value: os.environ/FIREFLY_MCP_TOKEN`.

## Test plan
- [x] Deployed the new image (same tag/digest, real `FIREFLY_OAUTH_CLIENT_ID`, real `MCP_BASE_URL`) to a scratch `firefly-mcp-test` namespace via the flux MCP tool.
- [x] Pod reached `Running`/`1/1 Ready` with no restarts; logs show a clean boot with no `MCP_BASE_URL` warnings.
- [x] Confirmed `GET /.well-known/oauth-authorization-server` → `200` (OAuth client is configured, surface is live but unused) and an unauthenticated request → `401`.
- [x] Pulled the real Firefly PAT directly from the existing `firefly-mcp-secret` Kubernetes secret (kept out of all command output/logs) and called `initialize` over the live root-path MCP endpoint with it as a Bearer token → valid response.
- [x] Called the `get_transactions` tool (`limit: 10`) with that same PAT and got back 10 real transactions from the live Firefly III instance (verified actual transaction data, not just a connectivity check).
- [x] Cleaned up all scratch test resources (namespace, deployment, service) afterward.