### PR TITLE
Add Umami analytics deployment

### DIFF
--- a/apps/mirceanton/kustomization.yaml
+++ b/apps/mirceanton/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mirceanton
+
+resources:
+  - ./namespace.yaml
+  - ./umami

--- a/apps/mirceanton/namespace.yaml
+++ b/apps/mirceanton/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mirceanton
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/apps/mirceanton/umami/app.ks.yaml
+++ b/apps/mirceanton/umami/app.ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app umami
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: mirceanton
+
+  path: ./apps/mirceanton/umami/app
+  components:
+    - ../../../../components/cnpg/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: 1password-connect
+      namespace: security-system

--- a/apps/mirceanton/umami/app/external-secret.yaml
+++ b/apps/mirceanton/umami/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: umami-keys
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: umami-keys
+    creationPolicy: Owner
+
+  data:
+    - secretKey: APP_SECRET
+      remoteRef:
+        key: Umami Keys
+        property: APP_SECRET

--- a/apps/mirceanton/umami/app/helm-release.yaml
+++ b/apps/mirceanton/umami/app/helm-release.yaml
@@ -1,0 +1,114 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app umami
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: umami
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      umami:
+        replicas: 1
+        initContainers:
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.6.0
+            args: ["postgresql", "$(DB_URL)"]
+            env:
+              DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: umami-postgres-app
+                    key: uri
+        containers:
+          app:
+            image:
+              repository: ghcr.io/umami-software/umami
+              tag: 3.1.0
+            env:
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: umami-postgres-app
+                    key: uri
+              APP_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: umami-keys
+                    key: APP_SECRET
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/heartbeat
+                    port: &port 3000
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/heartbeat
+                    port: *port
+                  periodSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 25m
+                memory: 150Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: umami
+        ports:
+          http:
+            port: *port
+
+    route:
+      home:
+        hostnames: ["analytics.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      next-cache:
+        type: emptyDir
+        globalMounts:
+          - path: /app/.next/cache

--- a/apps/mirceanton/umami/app/kustomization.yaml
+++ b/apps/mirceanton/umami/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/mirceanton/umami/app/oci-repository.yaml
+++ b/apps/mirceanton/umami/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: umami
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/mirceanton/umami/kustomization.yaml
+++ b/apps/mirceanton/umami/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml


### PR DESCRIPTION
Deploys Umami via the bjw-s-labs app-template chart in a new
mirceanton namespace, backed by the CNPG postgres component and
exposed at analytics.home.mirceanton.com through envoy-internal.
