### PR TITLE
fix(renovate): disable automerge for CalVer-style versions

### DIFF
--- a/.renovate/versions.json5
+++ b/.renovate/versions.json5
@@ -2,6 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      "description": "Disable automerge for CalVer-style versions (e.g. YYYY.MM or YYYY.MM.DD), since they aren't real semver and a 'patch' bump can still ship breaking changes",
+      "matchCurrentVersion": "/^v?\\d{4}\\.\\d{1,2}(\\.\\d{1,2})?$/",
+      "automerge": false
+    },
+    {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["fireflyiii/core", "fireflyiii/data-importer"],
       "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"


### PR DESCRIPTION
Packages like nousresearch/hermes-agent are tagged with calendar dates
(e.g. v2026.6.19), which Renovate's default semver-ish comparison reads
as a harmless patch bump and automerges. Add a packageRule matching
that version shape and turn automerge off so these go through PR review.

Fixes #665