### PR TITLE
fix(firefly-mcp): remove throwaway OAuth client now that PAT-only mode is available

### DIFF
--- a/apps/finances/firefly/mcp/helm-release.yaml
+++ b/apps/finances/firefly/mcp/helm-release.yaml
@@ -26,13 +26,6 @@ spec:
 
             env:
               FIREFLY_URL: "http://firefly.finances.svc.cluster.local:8080"
-              # Public OAuth client (no secret) registered solely to satisfy this
-              # image's startup check. The actual credential is a PAT, forwarded
-              # by litellm as a Bearer token — the OAuth flow is never exercised.
-              # Remove once daften/fireflyiii-mcp ships native PAT-only HTTP mode
-              # (https://github.com/daften/fireflyiii-mcp/pull/30).
-              FIREFLY_OAUTH_CLIENT_ID: "019ed106-79b5-7361-8613-765e72e38098"
-              MCP_BASE_URL: "http://firefly-mcp.finances.svc.cluster.local:3000"
 
             probes:
               liveness: &probe


### PR DESCRIPTION
Renovate already bumped ghcr.io/daften/fireflyiii-mcp to 0.3.0, which
ships native PAT-only HTTP mode (daften/fireflyiii-mcp#30). The OAuth
client ID and base URL workaround are no longer needed since the PAT
forwarded by litellm as a Bearer token satisfies auth on its own.

Closes #656

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SDv15JRMrqZffMSkizpka8