### PR TITLE
feat(llmkube): move helm source to OCI registry

### DIFF
--- a/apps/ai/llmkube/app/helm-release.yaml
+++ b/apps/ai/llmkube/app/helm-release.yaml
@@ -6,13 +6,9 @@ metadata:
   name: llmkube
 spec:
   interval: 30m
-  chart:
-    spec:
-      chart: llmkube
-      version: 0.8.13
-      sourceRef:
-        kind: HelmRepository
-        name: llmkube
+  chartRef:
+    kind: OCIRepository
+    name: llmkube
 
   values:
     namespace: ai

--- a/apps/ai/llmkube/app/helm-repository.yaml
+++ b/apps/ai/llmkube/app/helm-repository.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/helmrepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: llmkube
-spec:
-  interval: 1h
-  url: https://defilantech.github.io/LLMKube

--- a/apps/ai/llmkube/app/kustomization.yaml
+++ b/apps/ai/llmkube/app/kustomization.yaml
@@ -3,5 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./helm-repository.yaml
+  - ./oci-repository.yaml
   - ./helm-release.yaml

--- a/apps/ai/llmkube/app/oci-repository.yaml
+++ b/apps/ai/llmkube/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: llmkube
+spec:
+  interval: 15m
+  url: oci://ghcr.io/defilantech/charts/llmkube
+  ref:
+    tag: 0.8.13
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy


### PR DESCRIPTION
LLMKube now publishes its chart to ghcr.io/defilantech/charts/llmkube,
so switch the HelmRelease off the GitHub Pages HelmRepository and onto
an OCIRepository, following the convention used by other apps.

Closes #671