### PR TITLE
feat(llmkube): run Qwen3 0.6B models on the AMD iGPU via Vulkan

### DIFF
--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -17,21 +17,21 @@ model_list:
       api_base: http://gemma-4-26b-a4b-proxy.ai.svc.cluster.local:8080
       api_key: "N/A"
 
-  # - model_name: qwen3-0.6b
-  #   litellm_params:
-  #     model: openai/qwen3-0.6b
-  #     api_base: http://qwen3-0-6b.ai.svc.cluster.local:8080
-  #     api_key: "N/A"
-  #   model_info:
-  #     supports_response_schema: false
+  - model_name: qwen3-0.6b
+    litellm_params:
+      model: openai/qwen3-0.6b
+      api_base: http://qwen3-0-6b.ai.svc.cluster.local:8080
+      api_key: "N/A"
+    model_info:
+      supports_response_schema: false
 
-  # - model_name: qwen3-embedding-0.6b
-  #   litellm_params:
-  #     model: openai/qwen3-embedding-0.6b
-  #     api_base: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080
-  #     api_key: "N/A"
-  #   model_info:
-  #     mode: embedding
+  - model_name: qwen3-embedding-0.6b
+    litellm_params:
+      model: openai/qwen3-embedding-0.6b
+      api_base: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080
+      api_key: "N/A"
+    model_info:
+      mode: embedding
 
 mcp_servers:
   github:

--- a/apps/ai/llmkube/models/kustomization.yaml
+++ b/apps/ai/llmkube/models/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - ./servicemonitor.yaml
   - ./qwen-35b.yaml
   - ./gemma-4-26B-A4B.yaml
-  # - ./qwen3-0.6b.yaml
-  # - ./qwen3-embedding-0.6b.yaml
+  - ./qwen3-0.6b.yaml
+  - ./qwen3-embedding-0.6b.yaml

--- a/apps/ai/llmkube/models/qwen3-0.6b.yaml
+++ b/apps/ai/llmkube/models/qwen3-0.6b.yaml
@@ -8,8 +8,14 @@ spec:
   format: gguf
   quantization: UD-Q8_K_XL
   hardware:
-    accelerator: cpu
-    gpu: { enabled: false }
+    accelerator: vulkan
+    gpu:
+      enabled: true
+      count: 1
+      vendor: amd
+      runtime: vulkan
+      layers: -1
+      resourceName: devic.es/dri-render
 
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -20,11 +26,12 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: qwen3-0.6b
-  image: ghcr.io/ggml-org/llama.cpp:server
+  image: ghcr.io/ggml-org/llama.cpp:server-vulkan
   replicas: 1
   priority: batch
-  parallelSlots: 4
+  parallelSlots: 1 # single concurrent session
 
+  flashAttention: true
   contextSize: 32768
   uBatchSize: 512
   cacheTypeK: q8_0
@@ -32,7 +39,9 @@ spec:
 
   resources:
     cpu: 500m # just for scheduling purposes...
-    memory: 1.5Gi
+    memory: 1Gi
+    gpu: 1
+    gpuMemory: 2Gi
 
   endpoint:
     port: 8080

--- a/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -8,8 +8,14 @@ spec:
   format: gguf
   quantization: Q8_0
   hardware:
-    accelerator: cpu
-    gpu: { enabled: false }
+    accelerator: vulkan
+    gpu:
+      enabled: true
+      count: 1
+      vendor: amd
+      runtime: vulkan
+      layers: -1
+      resourceName: devic.es/dri-render
 
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
@@ -20,11 +26,12 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: qwen3-embedding-0.6b
-  image: ghcr.io/ggml-org/llama.cpp:server
+  image: ghcr.io/ggml-org/llama.cpp:server-vulkan
   replicas: 1
   priority: batch
-  parallelSlots: 8
+  parallelSlots: 2 # up to 2 concurrent sessions
 
+  flashAttention: true
   contextSize: 32768
   uBatchSize: 2048
   extraArgs:
@@ -33,6 +40,8 @@ spec:
   resources:
     cpu: 500m
     memory: 1Gi
+    gpu: 1
+    gpuMemory: 3Gi
 
   endpoint:
     port: 8080

--- a/apps/kube-system/generic-device-plugin/app/helm-release.yaml
+++ b/apps/kube-system/generic-device-plugin/app/helm-release.yaml
@@ -60,6 +60,11 @@ spec:
                     paths:
                       - path: /dev/input
                         mountType: DirectoryOrCreate
+              - name: dri-render
+                groups:
+                  - count: 10
+                    paths:
+                      - path: /dev/dri/renderD128
 
     persistence:
       config:


### PR DESCRIPTION
## Summary
- Move `qwen3-0.6b` (chat) and `qwen3-embedding-0.6b` (embeddings) LLMKube models from CPU to the Ryzen 7 5700G iGPU, using llama.cpp's `server-vulkan` image (`hardware.accelerator: vulkan`, `gpu.vendor: amd`, `gpu.runtime: vulkan`, full layer offload).
- Expose the iGPU render node (`/dev/dri/renderD128`) through the existing `generic-device-plugin` as `devic.es/dri-render`, and reference it explicitly via `gpu.resourceName` on both models.
- Chat model tuned for a single concurrent session (`parallelSlots: 1`); embeddings model tuned for up to two (`parallelSlots: 2`).
- Re-enabled both models in the `llmkube-models` kustomization and in the LiteLLM `config.yaml` model list (they were previously commented out/disabled).

## Test plan
- [ ] Flux reconciles `generic-device-plugin` and confirms node advertises `devic.es/dri-render` (`kubectl describe node | grep dri-render`)
- [ ] `qwen3-0.6b` and `qwen3-embedding-0.6b` pods schedule and reach Ready, with llama.cpp logs showing Vulkan device detection and full layer offload
- [ ] Chat completion via LiteLLM (`qwen3-0.6b`) returns a response
- [ ] Embeddings request via LiteLLM (`qwen3-embedding-0.6b`) returns vectors


---
_Generated by [Claude Code](https://claude.ai/code/session_01N7ry3U4obMyPtXi341pDFw)_