### PR TITLE
fix(mise): sync mise.lock with talosctl 1.13.5 and auto-update lockfile via renovate

### DIFF
--- a/.renovate/managers.json5
+++ b/.renovate/managers.json5
@@ -15,5 +15,13 @@
 
   "helmfile": {
     "managerFilePatterns": ["/helmfile\\.yaml$/"]
+  },
+
+  "mise": {
+    "postUpgradeTasks": {
+      "commands": ["mise install"],
+      "fileFilters": ["mise.lock"],
+      "executionMode": "branch"
+    }
   }
 }

--- a/apps/github-actions/renovate/jobs/renovate-job.yaml
+++ b/apps/github-actions/renovate/jobs/renovate-job.yaml
@@ -28,7 +28,7 @@ spec:
       value: debug
     - name: RENOVATE_ALLOWED_COMMANDS
       value: |-
-        ["pnpm run bundle"]
+        ["pnpm run bundle", "mise install"]
     - name: DOCKERHUB_USERNAME
       valueFrom:
         secretKeyRef:

--- a/mise.lock
+++ b/mise.lock
@@ -324,42 +324,42 @@ checksum = "sha256:7bf1aad1fbe0c3c6a866e02731e71db500bbd2ac0c965958309e61edbc14e
 url = "https://github.com/budimanjojo/talhelper/releases/download/v3.1.11/talhelper_windows_amd64.tar.gz"
 
 [[tools."aqua:talosctl"]]
-version = "1.13.4"
+version = "1.13.5"
 backend = "aqua:talosctl"
 
 [tools."aqua:talosctl"."platforms.linux-arm64"]
-checksum = "sha256:71cb14ab72aee8bd89d3ee08931747a9238a10025a689dc4117d532d4c6c444f"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.4/talosctl-linux-arm64"
+checksum = "sha256:bd053d8264c1b0c091cbaf15e7b414ab1cd14a56ddd5860f2e2ba01e5aee3bc3"
+url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-arm64"
 provenance = "cosign"
 
 [tools."aqua:talosctl"."platforms.linux-arm64-musl"]
-checksum = "sha256:71cb14ab72aee8bd89d3ee08931747a9238a10025a689dc4117d532d4c6c444f"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.4/talosctl-linux-arm64"
+checksum = "sha256:bd053d8264c1b0c091cbaf15e7b414ab1cd14a56ddd5860f2e2ba01e5aee3bc3"
+url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-arm64"
 provenance = "cosign"
 
 [tools."aqua:talosctl"."platforms.linux-x64"]
-checksum = "sha256:aae1dadd238f9dfbc9790d117a114424b2d59200ee12872d0d9f89e178a69aae"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.4/talosctl-linux-amd64"
+checksum = "sha256:cb12209727c0c4d57d74c0595f34d441ba491421e1d3c8a5142ed91028a20232"
+url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-amd64"
 provenance = "cosign"
 
 [tools."aqua:talosctl"."platforms.linux-x64-musl"]
-checksum = "sha256:aae1dadd238f9dfbc9790d117a114424b2d59200ee12872d0d9f89e178a69aae"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.4/talosctl-linux-amd64"
+checksum = "sha256:cb12209727c0c4d57d74c0595f34d441ba491421e1d3c8a5142ed91028a20232"
+url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-linux-amd64"
 provenance = "cosign"
 
 [tools."aqua:talosctl"."platforms.macos-arm64"]
-checksum = "sha256:2d86630f623486d247dac8eb0db1e2f9f581c4aebd201a193e4eaf7eb13392fa"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.4/talosctl-darwin-arm64"
+checksum = "sha256:5cfc42f5a51b01ea391c9760a1c5450517f7e85a74d145fd20b6abc4ac1df37e"
+url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-darwin-arm64"
 provenance = "cosign"
 
 [tools."aqua:talosctl"."platforms.macos-x64"]
-checksum = "sha256:bdee0433a4ef7668cea884b80b536f018160b0f998429d7440388c62a76e2062"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.4/talosctl-darwin-amd64"
+checksum = "sha256:b5808a8f650c53987d0133704259f3cdf31c081710bda598f9b4cab934abc78c"
+url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-darwin-amd64"
 provenance = "cosign"
 
 [tools."aqua:talosctl"."platforms.windows-x64"]
-checksum = "sha256:c3500946ad95b49fce4e8e6222c7a992ac76f6f4e490ce3984fc2176f1821c73"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.4/talosctl-windows-amd64.exe"
+checksum = "sha256:dd36d21d7157568387fa62e4f092b8a8536bb85f2362ababee493c503e48a0f2"
+url = "https://github.com/siderolabs/talos/releases/download/v1.13.5/talosctl-windows-amd64.exe"
 provenance = "cosign"
 
 [[tools.direnv]]


### PR DESCRIPTION
## Summary

- The talosctl Renovate update bumped `.mise.toml` to `1.13.5` but `mise.lock` was left pinned to `1.13.4` (stale checksums/URLs), which made `mise install` fail in CI — this is why workflows started failing.
- Fixed `mise.lock` to match `.mise.toml` (`talosctl` `1.13.5`), with checksums/URLs verified against the upstream `sha256sum.txt` for that release and cross-checked against a real `mise install` run.
- Configured Renovate's `mise` manager with a `postUpgradeTasks` entry that runs `mise install` after any `mise.toml` update, so `mise.lock` is regenerated automatically going forward (`.renovate/managers.json5`).
- Added `mise install` to the Renovate operator's `RENOVATE_ALLOWED_COMMANDS` allowlist so the task is permitted to run (`apps/github-actions/renovate/jobs/renovate-job.yaml`).

## Test plan

- [x] Verified `.mise.toml`/`mise.lock` version mismatch was the root cause (reproduced failure locally with stale lock + updated config)
- [x] Downloaded `mise` and ran `mise install aqua:talosctl` locally; diffed the resulting lock entry against my manual fix — byte-for-byte identical
- [x] Ran `mise install` for the full toolset to confirm no other lockfile entries are out of sync
- [ ] Confirm CI workflows (`Lint`, `Flate`) pass on this PR
- [ ] Confirm a future mise-related Renovate PR picks up the lockfile automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015ThPEQ1gRrjPUdZQz4MNUP)_