### PR TITLE
feat(security): add ESO Grafana dashboard and PrometheusRules

### DIFF
--- a/apps/security-system/external-secrets-operator/app/external-secrets.json
+++ b/apps/security-system/external-secrets-operator/app/external-secrets.json
@@ -360,7 +360,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 6 },
       "id": 7,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -398,7 +398,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 6 },
       "id": 8,
       "options": {
         "displayMode": "gradient",
@@ -429,7 +429,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
       "id": 102,
       "panels": [],
       "title": "Sync Activity",
@@ -471,7 +471,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 15 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 19 },
       "id": 9,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -490,7 +490,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
       "id": 103,
       "panels": [],
       "title": "Reconcile Performance",
@@ -532,7 +532,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
       "id": 11,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -597,7 +597,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
       "id": 12,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -616,7 +616,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
       "id": 104,
       "panels": [],
       "title": "Controller Health",
@@ -658,7 +658,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 37 },
       "id": 13,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },

--- a/apps/security-system/external-secrets-operator/app/external-secrets.json
+++ b/apps/security-system/external-secrets-operator/app/external-secrets.json
@@ -1,0 +1,801 @@
+{
+  "uid": "external-secrets",
+  "title": "External Secrets Operator",
+  "description": "Operational dashboard for External Secrets Operator — tracks managed secrets, sync health, and controller activity.",
+  "timezone": "browser",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "1m",
+  "editable": true,
+  "schemaVersion": 42,
+  "version": 1,
+  "tags": ["external-secrets", "security", "secrets"],
+  "graphTooltip": 1,
+  "links": [],
+  "preload": false,
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(externalsecret_sync_calls_total{job=\"external-secrets-metrics\"}, exported_namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(externalsecret_sync_calls_total{job=\"external-secrets-metrics\"}, exported_namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Total number of ExternalSecret resources across selected namespaces.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "count(externalsecret_sync_calls_total{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"})",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ],
+      "title": "Total ExternalSecrets",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Number of ExternalSecrets with condition Ready=True. These secrets have been successfully synced from the secret backend.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(externalsecret_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\", status=\"True\", exported_namespace=~\"$namespace\"})",
+          "legendFormat": "Ready",
+          "refId": "A"
+        }
+      ],
+      "title": "Ready Secrets",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Number of ExternalSecrets with condition Ready=False. Any non-zero value warrants investigation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(externalsecret_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\", status=\"False\", exported_namespace=~\"$namespace\"})",
+          "legendFormat": "Not-Ready",
+          "refId": "A"
+        }
+      ],
+      "title": "Not-Ready Secrets",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Percentage of sync attempts that resulted in errors over the last 5 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "100 * sum(rate(externalsecret_sync_calls_error{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"}[5m])) / sum(rate(externalsecret_sync_calls_total{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"}[5m]))",
+          "legendFormat": "Error Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Sync Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Number of goroutines currently processing reconcile events for the ExternalSecret controller.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "controller_runtime_active_workers{job=\"external-secrets-metrics\", controller=\"externalsecret\"}",
+          "legendFormat": "Active",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Whether the External Secrets Operator metrics endpoint is currently reachable by Prometheus.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            {
+              "options": {
+                "0": { "color": "red", "index": 0, "text": "DOWN" },
+                "1": { "color": "green", "index": 1, "text": "UP" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "up{job=\"external-secrets-metrics\"}",
+          "legendFormat": "Status",
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Status",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "panels": [],
+      "title": "Secret Health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Number of ExternalSecrets in Ready and Not-Ready state over time. Dips in the Ready count indicate synchronization problems.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(externalsecret_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\", status=\"True\", exported_namespace=~\"$namespace\"})",
+          "legendFormat": "Ready",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(externalsecret_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\", status=\"False\", exported_namespace=~\"$namespace\"})",
+          "legendFormat": "Not-Ready",
+          "refId": "B"
+        }
+      ],
+      "title": "Ready vs Not-Ready",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Current count of ExternalSecrets broken down by target namespace.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 8,
+      "options": {
+        "displayMode": "gradient",
+        "fillOpacity": 80,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "count by (exported_namespace) (externalsecret_sync_calls_total{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"})",
+          "legendFormat": "{{exported_namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "ExternalSecrets per Namespace",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 102,
+      "panels": [],
+      "title": "Sync Activity",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rate of synchronization attempts per second, broken down by namespace.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(externalsecret_sync_calls_total{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"}[5m])) by (exported_namespace)",
+          "legendFormat": "{{exported_namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sync Call Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rate of failed sync attempts per second, broken down by namespace. Any persistent non-zero value indicates secrets that cannot be resolved from the backend.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(externalsecret_sync_calls_error{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"}[5m])) by (exported_namespace)",
+          "legendFormat": "{{exported_namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sync Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 103,
+      "panels": [],
+      "title": "Reconcile Performance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Reconcile duration percentiles (p50, p95, p99) for the ExternalSecret controller. High tail latencies may indicate slow secret backends or network issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{job=\"external-secrets-metrics\", controller=\"externalsecret\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(controller_runtime_reconcile_time_seconds_bucket{job=\"external-secrets-metrics\", controller=\"externalsecret\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{job=\"external-secrets-metrics\", controller=\"externalsecret\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Reconcile Duration (ExternalSecret)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rate of reconcile loops per second for each controller, broken down by result (requeue_after = normal, error = failure, success = instant completion).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(controller_runtime_reconcile_total{job=\"external-secrets-metrics\"}[5m])) by (controller, result)",
+          "legendFormat": "{{controller}} / {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Rate by Controller",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 104,
+      "panels": [],
+      "title": "Controller Health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rate of controller reconcile panics or fatal errors per second. Persistent errors indicate issues with the operator itself, distinct from individual secret sync failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 13,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(controller_runtime_reconcile_errors_total{job=\"external-secrets-metrics\"}[5m])) by (controller)",
+          "legendFormat": "{{controller}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Number of goroutines currently processing reconcile events per controller, compared against the configured maximum concurrency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 14,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "controller_runtime_active_workers{job=\"external-secrets-metrics\"}",
+          "legendFormat": "{{controller}} (active)",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "controller_runtime_max_concurrent_reconciles{job=\"external-secrets-metrics\"}",
+          "legendFormat": "{{controller}} (max)",
+          "refId": "B"
+        }
+      ],
+      "title": "Workers per Controller",
+      "type": "timeseries"
+    }
+  ],
+  "timepicker": {}
+}

--- a/apps/security-system/external-secrets-operator/app/external-secrets.json
+++ b/apps/security-system/external-secrets-operator/app/external-secrets.json
@@ -109,46 +109,6 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Number of ExternalSecrets with condition Ready=True. These secrets have been successfully synced from the secret backend.",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{ "color": "green", "value": 0 }]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
-      "id": 2,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.0",
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(externalsecret_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\", status=\"True\", exported_namespace=~\"$namespace\"})",
-          "legendFormat": "Ready",
-          "refId": "A"
-        }
-      ],
-      "title": "Ready Secrets",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "description": "Number of ExternalSecrets with condition Ready=False. Any non-zero value warrants investigation.",
       "fieldConfig": {
         "defaults": {
@@ -165,7 +125,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
       "id": 3,
       "options": {
         "colorMode": "background",
@@ -187,30 +147,26 @@
           "refId": "A"
         }
       ],
-      "title": "Not-Ready Secrets",
+      "title": "Not-Ready ExternalSecrets",
       "type": "stat"
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Percentage of sync attempts that resulted in errors over the last 5 minutes.",
+      "description": "Total number of ClusterSecretStore resources.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": 0 },
-              { "color": "yellow", "value": 5 },
-              { "color": "red", "value": 10 }
-            ]
+            "steps": [{ "color": "blue", "value": 0 }]
           },
-          "unit": "percent"
+          "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
-      "id": 4,
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 15,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -226,17 +182,60 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "100 * sum(rate(externalsecret_sync_calls_error{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"}[5m])) / sum(rate(externalsecret_sync_calls_total{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"}[5m]))",
-          "legendFormat": "Error Rate",
+          "expr": "count(clustersecretstore_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\"})",
+          "legendFormat": "Total",
           "refId": "A"
         }
       ],
-      "title": "Sync Error Rate",
+      "title": "Total ClusterSecretStores",
       "type": "stat"
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Number of goroutines currently processing reconcile events for the ExternalSecret controller.",
+      "description": "Number of ClusterSecretStores with condition Ready=False. Any non-zero value means all ExternalSecrets referencing that store will fail to sync.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 17,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(clustersecretstore_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\", status=\"False\"})",
+          "legendFormat": "Not-Ready",
+          "refId": "A"
+        }
+      ],
+      "title": "Not-Ready ClusterSecretStores",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Total number of namespaced SecretStore resources.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -250,7 +249,7 @@
         "overrides": []
       },
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
-      "id": 5,
+      "id": 18,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -266,34 +265,26 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "controller_runtime_active_workers{job=\"external-secrets-metrics\", controller=\"externalsecret\"}",
-          "legendFormat": "Active",
+          "expr": "count(secretstore_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\"})",
+          "legendFormat": "Total",
           "refId": "A"
         }
       ],
-      "title": "Active Workers",
+      "title": "Total SecretStores",
       "type": "stat"
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Whether the External Secrets Operator metrics endpoint is currently reachable by Prometheus.",
+      "description": "Number of namespaced SecretStores with condition Ready=False.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "mappings": [
-            {
-              "options": {
-                "0": { "color": "red", "index": 0, "text": "DOWN" },
-                "1": { "color": "green", "index": 1, "text": "UP" }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": 0 },
-              { "color": "green", "value": 1 }
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 1 }
             ]
           },
           "unit": "short"
@@ -301,7 +292,7 @@
         "overrides": []
       },
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
-      "id": 6,
+      "id": 20,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -317,12 +308,12 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "up{job=\"external-secrets-metrics\"}",
-          "legendFormat": "Status",
+          "expr": "sum(secretstore_status_condition{job=\"external-secrets-metrics\", condition=\"Ready\", status=\"False\"})",
+          "legendFormat": "Not-Ready",
           "refId": "A"
         }
       ],
-      "title": "Controller Status",
+      "title": "Not-Ready SecretStores",
       "type": "stat"
     },
     {
@@ -480,7 +471,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 15 },
       "id": 9,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -495,59 +486,6 @@
         }
       ],
       "title": "Sync Call Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Rate of failed sync attempts per second, broken down by namespace. Any persistent non-zero value indicates secrets that cannot be resolved from the backend.",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{ "color": "green", "value": 0 }]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
-      "id": 10,
-      "options": {
-        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(externalsecret_sync_calls_error{job=\"external-secrets-metrics\", exported_namespace=~\"$namespace\"}[5m])) by (exported_namespace)",
-          "legendFormat": "{{exported_namespace}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Sync Error Rate",
       "type": "timeseries"
     },
     {
@@ -720,7 +658,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
       "id": 13,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -735,65 +673,6 @@
         }
       ],
       "title": "Reconcile Error Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Number of goroutines currently processing reconcile events per controller, compared against the configured maximum concurrency.",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{ "color": "green", "value": 0 }]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
-      "id": 14,
-      "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "controller_runtime_active_workers{job=\"external-secrets-metrics\"}",
-          "legendFormat": "{{controller}} (active)",
-          "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "controller_runtime_max_concurrent_reconciles{job=\"external-secrets-metrics\"}",
-          "legendFormat": "{{controller}} (max)",
-          "refId": "B"
-        }
-      ],
-      "title": "Workers per Controller",
       "type": "timeseries"
     }
   ],

--- a/apps/security-system/external-secrets-operator/app/external-secrets.json
+++ b/apps/security-system/external-secrets-operator/app/external-secrets.json
@@ -360,7 +360,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 6 },
+      "gridPos": { "h": 14, "w": 12, "x": 0, "y": 6 },
       "id": 7,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -398,7 +398,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 6 },
+      "gridPos": { "h": 14, "w": 12, "x": 12, "y": 6 },
       "id": 8,
       "options": {
         "displayMode": "gradient",
@@ -429,7 +429,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
       "id": 102,
       "panels": [],
       "title": "Sync Activity",
@@ -471,7 +471,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 19 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 21 },
       "id": 9,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -490,7 +490,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 29 },
       "id": 103,
       "panels": [],
       "title": "Reconcile Performance",
@@ -532,7 +532,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 30 },
       "id": 11,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -597,7 +597,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 30 },
       "id": 12,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -616,7 +616,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 38 },
       "id": 104,
       "panels": [],
       "title": "Controller Health",
@@ -658,7 +658,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 37 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 39 },
       "id": 13,
       "options": {
         "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true },

--- a/apps/security-system/external-secrets-operator/app/kustomization.yaml
+++ b/apps/security-system/external-secrets-operator/app/kustomization.yaml
@@ -5,4 +5,13 @@ kind: Kustomization
 resources:
   - ./helm-release.yaml
   - ./oci-repository.yaml
+
+  - ./prometheus-rule.yaml
   - ./grafana-dashboard.yaml
+
+configMapGenerator:
+  - name: external-secrets-dashboard
+    options:
+      disableNameSuffixHash: true
+    files:
+      - external-secrets.json

--- a/apps/security-system/external-secrets-operator/app/prometheus-rule.yaml
+++ b/apps/security-system/external-secrets-operator/app/prometheus-rule.yaml
@@ -79,3 +79,42 @@ spec:
               The ExternalSecret controller is encountering reconcile panics or fatal errors at
               {{ $value | humanize }} errors/s. This is distinct from sync failures and may indicate
               a bug or resource constraint in the operator itself.
+
+        # ---- Secret Store Health ----
+        - record: job:clustersecretstore_ready:sum
+          expr: sum(clustersecretstore_status_condition{job="external-secrets-metrics", condition="Ready", status="True"})
+
+        - record: job:clustersecretstore_not_ready:sum
+          expr: sum(clustersecretstore_status_condition{job="external-secrets-metrics", condition="Ready", status="False"})
+
+        - record: job:secretstore_ready:sum
+          expr: sum(secretstore_status_condition{job="external-secrets-metrics", condition="Ready", status="True"})
+
+        - record: job:secretstore_not_ready:sum
+          expr: sum(secretstore_status_condition{job="external-secrets-metrics", condition="Ready", status="False"})
+
+        - alert: ESOClusterSecretStoreNotReady
+          expr: >-
+            clustersecretstore_status_condition{job="external-secrets-metrics", condition="Ready", status="False"} == 1
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "ClusterSecretStore {{ $labels.name }} is not Ready"
+            description: >-
+              ClusterSecretStore {{ $labels.name }} has reported Ready=False for over 5 minutes.
+              All ExternalSecrets across any namespace that reference this store will fail to sync.
+              Check the store configuration and the secret backend connectivity.
+
+        - alert: ESOSecretStoreNotReady
+          expr: >-
+            secretstore_status_condition{job="external-secrets-metrics", condition="Ready", status="False"} == 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SecretStore {{ $labels.exported_namespace }}/{{ $labels.name }} is not Ready"
+            description: >-
+              SecretStore {{ $labels.name }} in namespace {{ $labels.exported_namespace }} has reported
+              Ready=False for over 5 minutes. ExternalSecrets in that namespace that reference this
+              store will fail to sync. Check the store configuration and backend connectivity.

--- a/apps/security-system/external-secrets-operator/app/prometheus-rule.yaml
+++ b/apps/security-system/external-secrets-operator/app/prometheus-rule.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-secrets
+spec:
+  groups:
+    - name: external-secrets.rules
+      rules:
+        # ---- Recording Rules ----
+        - record: job:externalsecret_sync_calls:rate5m
+          expr: sum(rate(externalsecret_sync_calls_total{job="external-secrets-metrics"}[5m])) by (exported_namespace)
+
+        - record: job:externalsecret_sync_errors:rate5m
+          expr: sum(rate(externalsecret_sync_calls_error{job="external-secrets-metrics"}[5m])) by (exported_namespace)
+
+        - record: job:externalsecret_ready:sum
+          expr: sum(externalsecret_status_condition{job="external-secrets-metrics", condition="Ready", status="True"})
+
+        - record: job:externalsecret_not_ready:sum
+          expr: sum(externalsecret_status_condition{job="external-secrets-metrics", condition="Ready", status="False"})
+
+        # ---- Availability ----
+        - alert: ESODown
+          expr: absent(up{job="external-secrets-metrics"} == 1)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "External Secrets Operator metrics endpoint is absent"
+            description: >-
+              Prometheus cannot find any External Secrets Operator scrape target.
+              The controller may be down or the ServiceMonitor misconfigured.
+
+        # ---- Sync Health ----
+        - alert: ESOSyncFailuresHigh
+          expr: >-
+            (
+              sum(rate(externalsecret_sync_calls_error{job="external-secrets-metrics"}[5m]))
+              /
+              sum(rate(externalsecret_sync_calls_total{job="external-secrets-metrics"}[5m]))
+            ) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "External Secrets Operator sync failure rate is elevated"
+            description: >-
+              More than 10% of ExternalSecret sync attempts are failing over the last 5 minutes.
+              Some secrets may be stale or failing to resolve from the secret backend.
+              Check the operator logs and the secret backend (e.g. 1Password Connect) for errors.
+
+        - alert: ESONoSuccessfulSync
+          expr: >-
+            sum(externalsecret_status_condition{job="external-secrets-metrics", condition="Ready", status="True"}) == 0
+            and on()
+            sum(externalsecret_status_condition{job="external-secrets-metrics", condition="Ready", status="False"}) > 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "No ExternalSecrets are in a Ready state"
+            description: >-
+              All tracked ExternalSecrets report Ready=False for over 15 minutes.
+              This may indicate a secret backend outage or a misconfigured ClusterSecretStore.
+              Applications depending on these secrets may fail to start or operate correctly.
+
+        # ---- Error Rates ----
+        - alert: ESOReconcileErrorsHigh
+          expr: >-
+            sum(rate(controller_runtime_reconcile_errors_total{job="external-secrets-metrics", controller="externalsecret"}[5m])) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "External Secrets Operator controller reconcile error rate is elevated"
+            description: >-
+              The ExternalSecret controller is encountering reconcile panics or fatal errors at
+              {{ $value | humanize }} errors/s. This is distinct from sync failures and may indicate
+              a bug or resource constraint in the operator itself.


### PR DESCRIPTION
## Summary

- Adds a `GrafanaDashboard` for External Secrets Operator with 4 rows: Overview, Secret Health, Sync Activity, Reconcile Performance, and Controller Health
- Overview row shows total/not-ready counts for ExternalSecrets, ClusterSecretStores, and SecretStores at a glance
- Adds a `PrometheusRule` with recording rules and alerts for sync failures, store readiness (`ESODown`, `ESOSyncFailuresHigh`, `ESONoSuccessfulSync`, `ESOReconcileErrorsHigh`, `ESOClusterSecretStoreNotReady`, `ESOSecretStoreNotReady`)

## Test plan

- [ ] Dashboard visible in Grafana at `/d/external-secrets/external-secrets-operator`
- [ ] All 6 overview stat panels show correct counts
- [ ] PrometheusRule loaded — verify with `kubectl get prometheusrule external-secrets -n security-system`
- [ ] Alerts appear in Prometheus/Alertmanager UI