### PR TITLE
feat(Outline): add wiki app to productivity namespace

### DIFF
--- a/apps/productivity/outline/app.ks.yaml
+++ b/apps/productivity/outline/app.ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app outline
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: productivity
+
+  path: ./apps/productivity/outline/app
+  components:
+    - ../../../../components/cnpg/
+    - ../../../../components/volsync/
+    - ../../../../components/dragonfly/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: dragonfly-operator
+      namespace: database-system

--- a/apps/productivity/outline/app/external-secret.yaml
+++ b/apps/productivity/outline/app/external-secret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name outline-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    - secretKey: SECRET_KEY
+      remoteRef:
+        key: Outline - Keys
+        property: secret_key
+
+    - secretKey: UTILS_SECRET
+      remoteRef:
+        key: Outline - Keys
+        property: utils_secret
+
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: Outline - Keycloak
+        property: keycloak_client_secret

--- a/apps/productivity/outline/app/helm-release.yaml
+++ b/apps/productivity/outline/app/helm-release.yaml
@@ -116,6 +116,68 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
 
+      # https://docs.getoutline.com/s/hosting/doc/scheduled-jobs-RhZzCt770H
+      outline-cron-hourly:
+        type: cronjob
+        cronjob:
+          schedule: "0 * * * *" # hourly
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+
+        pod:
+          restartPolicy: OnFailure
+
+        containers:
+          app: &cronContainer
+            image:
+              repository: docker.io/curlimages/curl
+              tag: 8.21.0
+
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                curl --fail --silent --show-error -K - "https://wiki.home.mirceanton.com/api/cron.hourly" <<EOF
+                data = "token=$UTILS_SECRET"
+                EOF
+
+            env:
+              UTILS_SECRET:
+                valueFrom:
+                  secretKeyRef: { name: outline-secret, key: UTILS_SECRET }
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+      outline-cron-daily:
+        type: cronjob
+        cronjob:
+          schedule: "0 3 * * *" # daily at 3am
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+
+        pod:
+          restartPolicy: OnFailure
+
+        containers:
+          app:
+            <<: *cronContainer
+            args:
+              - |
+                curl --fail --silent --show-error -K - "https://wiki.home.mirceanton.com/api/cron.daily" <<EOF
+                data = "token=$UTILS_SECRET"
+                EOF
+
     service:
       app:
         controller: outline
@@ -133,13 +195,19 @@ spec:
     persistence:
       data:
         existingClaim: ${APP}
-        globalMounts:
-          - path: /var/lib/outline/data
+        advancedMounts:
+          outline:
+            app:
+              - path: /var/lib/outline/data
       tmp:
         type: emptyDir
-        globalMounts:
-          - path: /tmp
+        advancedMounts:
+          outline:
+            app:
+              - path: /tmp
       home:
         type: emptyDir
-        globalMounts:
-          - path: /home/node
+        advancedMounts:
+          outline:
+            app:
+              - path: /home/node

--- a/apps/productivity/outline/app/helm-release.yaml
+++ b/apps/productivity/outline/app/helm-release.yaml
@@ -1,0 +1,145 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app outline
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: outline
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      outline:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.6.0
+            args: ["postgresql", "$(DB_URL)"]
+            env:
+              DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: outline-postgres-app
+                    key: uri
+
+          wait-for-dragonfly:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.6.0
+            args: ["redis", "redis://outline-dragonfly:6379"]
+
+        containers:
+          app:
+            image:
+              repository: docker.io/outlinewiki/outline
+              tag: 1.9.2-0
+
+            envFrom:
+              - secretRef: { name: outline-secret }
+            env:
+              TZ: "Europe/Bucharest"
+              URL: "https://wiki.home.mirceanton.com"
+              PORT: &port 3000
+              FORCE_HTTPS: "false"
+              ENABLE_UPDATES: "false"
+              WEB_CONCURRENCY: "1"
+
+              FILE_STORAGE: local
+              FILE_STORAGE_LOCAL_ROOT_DIR: /var/lib/outline/data
+              FILE_STORAGE_UPLOAD_MAX_SIZE: "26214400"
+
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef: { name: outline-postgres-app, key: uri }
+              REDIS_URL: "redis://outline-dragonfly:6379"
+
+              OIDC_CLIENT_ID: "outline"
+              OIDC_DISPLAY_NAME: "Keycloak"
+              OIDC_SCOPES: "openid profile email"
+              OIDC_USERNAME_CLAIM: "preferred_username"
+              OIDC_AUTH_URI: "https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab/protocol/openid-connect/auth"
+              OIDC_TOKEN_URI: "https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab/protocol/openid-connect/token"
+              OIDC_USERINFO_URI: "https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab/protocol/openid-connect/userinfo"
+
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /_health
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /_health
+                    port: *port
+                  periodSeconds: 5
+                  failureThreshold: 30
+
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      app:
+        controller: outline
+        ports:
+          http:
+            port: *port
+
+    route:
+      home:
+        hostnames: ["wiki.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      data:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /var/lib/outline/data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      home:
+        type: emptyDir
+        globalMounts:
+          - path: /home/node

--- a/apps/productivity/outline/app/helm-release.yaml
+++ b/apps/productivity/outline/app/helm-release.yaml
@@ -53,7 +53,7 @@ spec:
           app:
             image:
               repository: docker.io/outlinewiki/outline
-              tag: 1.9.2-0
+              tag: 1.9.1
 
             envFrom:
               - secretRef: { name: outline-secret }

--- a/apps/productivity/outline/app/kustomization.yaml
+++ b/apps/productivity/outline/app/kustomization.yaml
@@ -2,9 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: productivity
-
 resources:
-  - ./namespace.yaml
-  - ./outline
-  - ./vikunja
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/productivity/outline/app/oci-repository.yaml
+++ b/apps/productivity/outline/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: outline
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/productivity/outline/kustomization.yaml
+++ b/apps/productivity/outline/kustomization.yaml
@@ -2,9 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: productivity
-
 resources:
-  - ./namespace.yaml
-  - ./outline
-  - ./vikunja
+  - ./app.ks.yaml


### PR DESCRIPTION
Deploys Outline using app-template with CNPG/dragonfly components
for postgres/redis and volsync-backed local file storage instead of
S3. Native OIDC login is wired to the Homelab Keycloak realm,
matching the vikunja/sure pattern already used in this repo.