### PR TITLE
feat(headlamp): deploy Headlamp to flux-system namespace

### DIFF
--- a/apps/default/homer/app/files/admin.yaml
+++ b/apps/default/homer/app/files/admin.yaml
@@ -36,6 +36,12 @@ services:
         target: "_blank"
         logo: "assets/icons/webp/renovate.webp"
 
+      - name: "Headlamp"
+        subtitle: "Kubernetes Dashboard"
+        url: "https://headlamp.admin.mirceanton.com"
+        target: "_blank"
+        logo: "assets/icons/webp/headlamp.webp"
+
   - name: "Networking"
     icon: "fas fa-network-wired"
     items:

--- a/apps/flux-system/headlamp/app.ks.yaml
+++ b/apps/flux-system/headlamp/app.ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app headlamp
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: flux-system
+
+  path: ./apps/flux-system/headlamp/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+
+  dependsOn:
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: 1password-connect
+      namespace: security-system

--- a/apps/flux-system/headlamp/app/external-secret.yaml
+++ b/apps/flux-system/headlamp/app/external-secret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name headlamp-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        OIDC_CLIENT_ID: headlamp
+        OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+        OIDC_SCOPES: "openid email profile"
+        OIDC_CLIENT_SECRET: "{{ .OIDC_CLIENT_SECRET }}"
+
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: Headlamp - Keycloak
+        property: keycloak_client_secret

--- a/apps/flux-system/headlamp/app/helm-release.yaml
+++ b/apps/flux-system/headlamp/app/helm-release.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: headlamp
+
+  values:
+    fullnameOverride: headlamp
+
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+
+    config:
+      pluginsDir: /build/plugins
+      oidc:
+        externalSecret:
+          enabled: true
+          name: headlamp-secret
+          hasScopes: true
+
+    initContainers:
+      - name: headlamp-plugins
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.6.0
+        command: ["/bin/sh", "-c"]
+        args:
+          - mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/
+        volumeMounts:
+          - name: headlamp-plugins
+            mountPath: /build/plugins
+
+    volumeMounts:
+      - name: headlamp-plugins
+        mountPath: /build/plugins
+
+    volumes:
+      - name: headlamp-plugins
+        emptyDir: {}
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        cpu: null
+        memory: 512Mi

--- a/apps/flux-system/headlamp/app/http-route.yaml
+++ b/apps/flux-system/headlamp/app/http-route.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlamp
+spec:
+  hostnames: ["headlamp.admin.mirceanton.com"]
+  parentRefs:
+    - name: envoy-admin
+      namespace: network-system
+  rules:
+    - backendRefs:
+        - name: headlamp
+          namespace: flux-system
+          port: 80

--- a/apps/flux-system/headlamp/app/kustomization.yaml
+++ b/apps/flux-system/headlamp/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml
+  - ./http-route.yaml

--- a/apps/flux-system/headlamp/app/oci-repository.yaml
+++ b/apps/flux-system/headlamp/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: headlamp
+spec:
+  interval: 15m
+  url: oci://ghcr.io/home-operations/charts-mirror/headlamp
+  ref:
+    tag: 0.43.0
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/flux-system/headlamp/kustomization.yaml
+++ b/apps/flux-system/headlamp/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/flux-system/kustomization.yaml
+++ b/apps/flux-system/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./flux-operator
   - ./flux-instance
   - ./flux-mcp
+  - ./headlamp


### PR DESCRIPTION
Adds the official Headlamp Helm chart with OIDC login against Keycloak and the Flux plugin baked in via an init container, exposed on the admin gateway.