### PR TITLE
feat(litellm): add Qwen cloud models and app-scoped model aliases

### DIFF
--- a/apps/ai/hermes/app/files/config.yaml
+++ b/apps/ai/hermes/app/files/config.yaml
@@ -1,5 +1,5 @@
 model:
-  default: qwen3.7-plus
+  default: hermes
 
 providers:
   litellm:

--- a/apps/ai/hermes/app/files/config.yaml
+++ b/apps/ai/hermes/app/files/config.yaml
@@ -1,5 +1,5 @@
 model:
-  default: gemma-4-12b
+  default: qwen3.7-plus
 
 providers:
   litellm:

--- a/apps/ai/litellm/app/external-secret.yaml
+++ b/apps/ai/litellm/app/external-secret.yaml
@@ -21,6 +21,7 @@ spec:
         master-key: '{{ index . "master-key" }}'
         salt-key: '{{ index . "salt-key" }}'
         GITHUB_MCP_TOKEN: "{{ .token }}"
+        QWEN_KEY: "{{ .QWEN_KEY }}"
 
   data:
     - secretKey: master-key
@@ -32,6 +33,11 @@ spec:
       remoteRef:
         key: LiteLLM
         property: LITELLM_SALT_KEY
+
+    - secretKey: QWEN_KEY
+      remoteRef:
+        key: LiteLLM
+        property: QWEN_KEY
 
   dataFrom:
     - sourceRef:

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -30,6 +30,18 @@ model_list:
     model_info:
       mode: embedding
 
+  - model_name: qwen3.6-plus
+    litellm_params:
+      model: openai/qwen3.6-plus
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
+  - model_name: qwen3.6-max
+    litellm_params:
+      model: openai/qwen3.6-max
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
 mcp_servers:
   github:
     url: "http://github-mcp.ai.svc.cluster.local:8082/mcp"

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -72,27 +72,6 @@ model_list:
       api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
       api_key: os.environ/QWEN_KEY
 
-  # aliases: app-facing model names decoupled from the underlying model
-  - model_name: hermes
-    litellm_params:
-      model: openai/qwen3.7-plus
-      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
-      api_key: os.environ/QWEN_KEY
-
-  - model_name: karakeep
-    litellm_params:
-      model: openai/qwen3.5-flash
-      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
-      api_key: os.environ/QWEN_KEY
-
-  - model_name: karakeep-embeddings
-    litellm_params:
-      model: openai/qwen3-embedding-0.6b
-      api_base: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/v1
-      api_key: "N/A"
-    model_info:
-      mode: embedding
-
 mcp_servers:
   github:
     url: "http://github-mcp.ai.svc.cluster.local:8082/mcp"
@@ -121,6 +100,12 @@ mcp_servers:
   stockii:
     url: "http://stockii.bomkii.svc.cluster.local:8080/mcp/sse"
     transport: sse
+
+router_settings:
+  model_group_alias:
+    hermes: qwen3.7-plus
+    karakeep: qwen3.5-flash
+    karakeep-embeddings: qwen3-embedding-0.6b
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -66,14 +66,6 @@ model_list:
       api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
       api_key: os.environ/QWEN_KEY
 
-  - model_name: wan2.7-t2v
-    litellm_params:
-      model: openai/wan2.7-t2v
-      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
-      api_key: os.environ/QWEN_KEY
-    model_info:
-      mode: video_generation
-
 mcp_servers:
   github:
     url: "http://github-mcp.ai.svc.cluster.local:8082/mcp"

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -42,6 +42,38 @@ model_list:
       api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
       api_key: os.environ/QWEN_KEY
 
+  - model_name: qwen3.6-flash
+    litellm_params:
+      model: openai/qwen3.6-flash
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
+  - model_name: qwen3.7-plus
+    litellm_params:
+      model: openai/qwen3.7-plus
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
+  - model_name: qwen3.7-max
+    litellm_params:
+      model: openai/qwen3.7-max
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
+  - model_name: glm-5.2
+    litellm_params:
+      model: openai/glm-5.2
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
+  - model_name: wan2.7-t2v
+    litellm_params:
+      model: openai/wan2.7-t2v
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+    model_info:
+      mode: video_generation
+
 mcp_servers:
   github:
     url: "http://github-mcp.ai.svc.cluster.local:8082/mcp"

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -66,6 +66,19 @@ model_list:
       api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
       api_key: os.environ/QWEN_KEY
 
+  # aliases: app-facing model names decoupled from the underlying model
+  - model_name: hermes
+    litellm_params:
+      model: openai/qwen3.7-plus
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
+  - model_name: karakeep
+    litellm_params:
+      model: openai/qwen3.5-flash
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
 mcp_servers:
   github:
     url: "http://github-mcp.ai.svc.cluster.local:8082/mcp"

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -48,6 +48,12 @@ model_list:
       api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
       api_key: os.environ/QWEN_KEY
 
+  - model_name: qwen3.5-flash
+    litellm_params:
+      model: openai/qwen3.5-flash
+      api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      api_key: os.environ/QWEN_KEY
+
   - model_name: qwen3.7-plus
     litellm_params:
       model: openai/qwen3.7-plus

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -79,6 +79,14 @@ model_list:
       api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
       api_key: os.environ/QWEN_KEY
 
+  - model_name: karakeep-embeddings
+    litellm_params:
+      model: openai/qwen3-embedding-0.6b
+      api_base: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/v1
+      api_key: "N/A"
+    model_info:
+      mode: embedding
+
 mcp_servers:
   github:
     url: "http://github-mcp.ai.svc.cluster.local:8082/mcp"

--- a/apps/ai/litellm/app/helm-release.yaml
+++ b/apps/ai/litellm/app/helm-release.yaml
@@ -67,6 +67,12 @@ spec:
                     name: litellm-secret
                     key: GITHUB_MCP_TOKEN
 
+              QWEN_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secret
+                    key: QWEN_KEY
+
             resources:
               requests:
                 cpu: 10m

--- a/apps/media/karakeep/app/karakeep.helm-release.yaml
+++ b/apps/media/karakeep/app/karakeep.helm-release.yaml
@@ -32,7 +32,7 @@ spec:
               # LLM auto-tagging/summarization, routed through the LiteLLM gateway.
               # No vision model is deployed, so OCR_USE_LLM stays off (Tesseract handles OCR).
               OPENAI_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
-              INFERENCE_TEXT_MODEL: qwen35b-mtp
+              INFERENCE_TEXT_MODEL: karakeep
               EMBEDDING_TEXT_MODEL: qwen3-embedding-0.6b
               INFERENCE_ENABLE_AUTO_SUMMARIZATION: true
               BROWSER_WEB_URL: http://karakeep-chrome:9222

--- a/apps/media/karakeep/app/karakeep.helm-release.yaml
+++ b/apps/media/karakeep/app/karakeep.helm-release.yaml
@@ -33,7 +33,7 @@ spec:
               # No vision model is deployed, so OCR_USE_LLM stays off (Tesseract handles OCR).
               OPENAI_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
               INFERENCE_TEXT_MODEL: karakeep
-              EMBEDDING_TEXT_MODEL: qwen3-embedding-0.6b
+              EMBEDDING_TEXT_MODEL: karakeep-embeddings
               INFERENCE_ENABLE_AUTO_SUMMARIZATION: true
               BROWSER_WEB_URL: http://karakeep-chrome:9222
               CRAWLER_DOWNLOAD_BANNER_IMAGE: true


### PR DESCRIPTION
## Summary
- Adds Qwen cloud models (`qwen3.6-plus`, `qwen3.6-max`, `qwen3.6-flash`, `qwen3.7-plus`, `qwen3.7-max`) and `glm-5.2`, all routed through Alibaba's DashScope OpenAI-compatible endpoint (`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`), authenticated via a new `QWEN_KEY` secret pulled from the `LiteLLM` 1Password item.
- Adds app-scoped model aliases in LiteLLM's `model_list` so consuming apps reference a stable name instead of the underlying model directly: `hermes` → `qwen3.7-plus`, `karakeep` → `qwen3.5-flash`, `karakeep-embeddings` → `qwen3-embedding-0.6b`.
- Hermes now defaults to the `hermes` alias; Karakeep's `INFERENCE_TEXT_MODEL`/`EMBEDDING_TEXT_MODEL` now use the `karakeep`/`karakeep-embeddings` aliases.
- Considered moving Karakeep's text model to `qwen3.6-flash` instead of adding `qwen3.5-flash`, but pricing isn't close (~$0.10/$0.40 vs ~$0.19/$1.13 per million input/output tokens — roughly 2-3x), so kept it on `qwen3.5-flash`.
- Dropped an earlier `wan2.7-t2v` (Wan2 text-to-video) entry after verifying it can't work: DashScope video generation only runs through DashScope's native async job API, not `/compatible-mode/v1`, and LiteLLM has no DashScope video-generation integration to bridge that gap.

## Test plan
- [x] `yaml.safe_load` validated on all changed YAML files
- [ ] Confirm `QWEN_KEY` is set on the `LiteLLM` 1Password item (property `QWEN_KEY`) before this syncs, or the LiteLLM pod will fail to resolve `os.environ/QWEN_KEY`
- [ ] After Flux reconciles, verify Hermes and Karakeep can reach their aliased models through the LiteLLM proxy


---
_Generated by [Claude Code](https://claude.ai/code/session_0133DGKqjmVVHCspu4C11VwM)_