### PR TITLE
feat(finance): deploy Firefly III with MCP server

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -23,6 +23,13 @@
       "minimumGroupSize": 2
     },
     {
+      "description": "Group Firefly III components",
+      "groupName": "firefly-iii",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["/fireflyiii/"],
+      "minimumGroupSize": 2
+    },
+    {
       "description": "Group 1Password Connect components",
       "groupName": "1password-connect",
       "matchDatasources": ["docker"],

--- a/.renovate/versions.json5
+++ b/.renovate/versions.json5
@@ -8,6 +8,11 @@
     },
     {
       "matchDatasources": ["docker"],
+      "matchPackageNames": ["fireflyiii/core", "fireflyiii/data-importer"],
+      "versioning": "regex:^version-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+    },
+    {
+      "matchDatasources": ["docker"],
       "matchPackageNames": ["onerahmet/openai-whisper-asr-webservice"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-gpu$"
     },

--- a/apps/ai/litellm/app/external-secret.yaml
+++ b/apps/ai/litellm/app/external-secret.yaml
@@ -23,6 +23,7 @@ spec:
         GITHUB_MCP_TOKEN: "{{ .token }}"
         QWEN_KEY: "{{ .QWEN_KEY }}"
         OIDC_CLIENT_SECRET: "{{ .OIDC_CLIENT_SECRET }}"
+        FIREFLY_MCP_TOKEN: "{{ .FIREFLY_MCP_TOKEN }}"
 
   data:
     - secretKey: master-key
@@ -43,6 +44,11 @@ spec:
       remoteRef:
         key: LiteLLM - Keycloak
         property: keycloak_client_secret
+
+    - secretKey: FIREFLY_MCP_TOKEN
+      remoteRef:
+        key: "Firefly MCP"
+        property: token
 
   dataFrom:
     - sourceRef:

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -92,6 +92,11 @@ mcp_servers:
     auth_type: bearer_token
     auth_value: os.environ/GITHUB_MCP_TOKEN
 
+  firefly:
+    url: "http://firefly-mcp.finance.svc.cluster.local:3000"
+    auth_type: bearer_token
+    auth_value: os.environ/FIREFLY_MCP_TOKEN
+
   kubesearch:
     url: "http://kubesearch-mcp.ai.svc.cluster.local:3000/mcp"
 

--- a/apps/ai/litellm/app/helm-release.yaml
+++ b/apps/ai/litellm/app/helm-release.yaml
@@ -64,6 +64,11 @@ spec:
                   secretKeyRef:
                     name: litellm-secret
                     key: GITHUB_MCP_TOKEN
+              FIREFLY_MCP_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secret
+                    key: FIREFLY_MCP_TOKEN
               QWEN_KEY:
                 valueFrom:
                   secretKeyRef:

--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -90,6 +90,12 @@ services:
         target: "_blank"
         logo: "assets/icons/webp/sure.webp"
 
+      - name: "Firefly"
+        subtitle: "Financial Manager"
+        url: "https://firefly.home.mirceanton.com"
+        target: "_blank"
+        logo: "assets/icons/webp/firefly-iii.webp"
+
       - name: "Vikunja"
         subtitle: "Task Manager"
         url: "https://tasks.home.mirceanton.com"

--- a/apps/finance/firefly/app.ks.yaml
+++ b/apps/finance/firefly/app.ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firefly
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: finance
+
+  path: ./apps/finance/firefly/app
+  components:
+    - ../../../../components/cnpg/
+    - ../../../../components/volsync/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_PUID: "33"
+      VOLSYNC_PGID: "33"
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: cloudnative-pg-plugins
+      namespace: database-system

--- a/apps/finance/firefly/app/external-secret.yaml
+++ b/apps/finance/firefly/app/external-secret.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name firefly-keys
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    - secretKey: APP_KEY
+      remoteRef:
+        key: Firefly Keys
+        property: APP_KEY
+
+    - secretKey: STATIC_CRON_TOKEN
+      remoteRef:
+        key: Firefly Keys
+        property: STATIC_CRON_TOKEN
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &dataImporterName firefly-data-importer-token
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *dataImporterName
+    creationPolicy: Owner
+
+  data:
+    - secretKey: FIREFLY_III_ACCESS_TOKEN
+      remoteRef:
+        key: Firefly Data Importer
+        property: FIREFLY_III_ACCESS_TOKEN
+
+    - secretKey: LUNCH_FLOW_API_KEY
+      remoteRef:
+        key: Firefly Data Importer
+        property: LUNCH_FLOW_API_KEY

--- a/apps/finance/firefly/app/helm-release.yaml
+++ b/apps/finance/firefly/app/helm-release.yaml
@@ -1,0 +1,218 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app firefly
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: firefly
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+
+    controllers:
+      firefly:
+        initContainers:
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.6.0
+            args: ["postgresql", "$(DB_URL)"]
+            env:
+              DB_URL:
+                valueFrom:
+                  secretKeyRef: { name: firefly-postgres-app, key: uri }
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+        containers:
+          app:
+            image:
+              repository: fireflyiii/core
+              tag: version-6.6.6
+
+            envFrom:
+              - secretRef: { name: firefly-keys }
+            env:
+              TZ: "Europe/Bucharest"
+              SEND_TELEMETRY: "false"
+              TRUSTED_PROXIES: "**"
+              DEFAULT_LANGUAGE: "en_US"
+              DEFAULT_LOCALE: "equal"
+
+              SEND_REGISTRATION_MAIL: "false"
+              SEND_ERROR_MESSAGE: "false"
+              SEND_LOGIN_NEW_IP_WARNING: "false"
+
+              LOG_CHANNEL: "stdout"
+              AUDIT_LOG_CHANNEL: "stdout"
+              APP_LOG_LEVEL: "notice"
+              CACHE_DRIVER: "file"
+              SESSION_DRIVER: "file"
+
+              DB_CONNECTION: "pgsql"
+              DB_HOST:
+                valueFrom:
+                  secretKeyRef: { name: firefly-postgres-app, key: host }
+              DB_PORT:
+                valueFrom:
+                  secretKeyRef: { name: firefly-postgres-app, key: port }
+              DB_DATABASE:
+                valueFrom:
+                  secretKeyRef: { name: firefly-postgres-app, key: dbname }
+              DB_USERNAME:
+                valueFrom:
+                  secretKeyRef: { name: firefly-postgres-app, key: username }
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef: { name: firefly-postgres-app, key: password }
+
+            probes:
+              startup: { enabled: true }
+              liveness: { enabled: true }
+              readiness: { enabled: true }
+
+            resources:
+              requests:
+                cpu: 20m
+                memory: 128Mi
+              limits:
+                memory: 2Gi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+      cron:
+        type: cronjob
+        cronjob:
+          schedule: "0 * * * *" # Every hour
+          successfulJobsHistory: 1
+          failedJobsHistory: 3
+          concurrencyPolicy: Forbid
+
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            fsGroupChangePolicy: OnRootMismatch
+
+        containers:
+          cron:
+            image:
+              repository: curlimages/curl
+              tag: 8.21.0
+            command:
+              - sh
+              - -c
+              - curl -sS "http://firefly:8080/api/v1/cron/${STATIC_CRON_TOKEN}"
+
+            env:
+              STATIC_CRON_TOKEN:
+                valueFrom:
+                  secretKeyRef: { name: firefly-keys, key: STATIC_CRON_TOKEN }
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+      data-importer:
+        containers:
+          main:
+            image:
+              repository: fireflyiii/data-importer
+              tag: version-2.3.4
+
+            envFrom:
+              - secretRef: { name: firefly-data-importer-token }
+            env:
+              FIREFLY_III_URL: "http://firefly:8080"
+              VANITY_URL: "https://firefly.home.mirceanton.com"
+              APP_URL: "https://firefly-importer.home.mirceanton.com"
+              TRUSTED_PROXIES: "**"
+              LOG_CHANNEL: "stdout"
+              FALLBACK_LOCALE: "en_US"
+
+            probes:
+              liveness: { enabled: true }
+              readiness: { enabled: true }
+
+            resources:
+              requests:
+                cpu: 20m
+                memory: 64Mi
+              limits:
+                memory: 8Gi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      firefly:
+        controller: firefly
+        ports:
+          http:
+            port: 8080
+      data-importer:
+        controller: data-importer
+        ports:
+          http:
+            port: 8080
+
+    route:
+      home:
+        hostnames: ["firefly.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+        rules:
+          - backendRefs:
+              - identifier: firefly
+                port: http
+      importer:
+        hostnames: ["firefly-importer.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+        rules:
+          - backendRefs:
+              - identifier: data-importer
+                port: http
+
+    persistence:
+      data:
+        existingClaim: ${APP}
+        advancedMounts:
+          firefly:
+            app:
+              - subPath: data
+                path: /var/www/html/storage
+              - subPath: upload
+                path: /var/www/html/storage/upload
+          data-importer:
+            main:
+              - subPath: importer
+                path: /var/www/html/storage/uploads

--- a/apps/finance/firefly/app/helm-release.yaml
+++ b/apps/finance/firefly/app/helm-release.yaml
@@ -54,6 +54,13 @@ spec:
               SEND_ERROR_MESSAGE: "false"
               SEND_LOGIN_NEW_IP_WARNING: "false"
 
+              # SSO via Keycloak: Envoy Gateway (see oidc.yaml) does the login
+              # and injects the verified email claim into a Remote-User
+              # header that Firefly trusts without further checks - native
+              # username/password login is disabled as a result.
+              AUTHENTICATION_GUARD: "remote_user_guard"
+              AUTHENTICATION_GUARD_HEADER: "HTTP_REMOTE_USER"
+
               LOG_CHANNEL: "stdout"
               AUDIT_LOG_CHANNEL: "stdout"
               APP_LOG_LEVEL: "notice"

--- a/apps/finance/firefly/app/kustomization.yaml
+++ b/apps/finance/firefly/app/kustomization.yaml
@@ -2,9 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: finance
-
 resources:
-  - ./namespace.yaml
-  - ./firefly
-  - ./sure
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/finance/firefly/app/kustomization.yaml
+++ b/apps/finance/firefly/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
   - ./external-secret.yaml
+  - ./oidc.yaml

--- a/apps/finance/firefly/app/oci-repository.yaml
+++ b/apps/finance/firefly/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: firefly
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/finance/firefly/app/oidc.yaml
+++ b/apps/finance/firefly/app/oidc.yaml
@@ -1,0 +1,116 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/gateway.envoyproxy.io/backend_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: firefly-keycloak
+spec:
+  endpoints:
+    - fqdn:
+        hostname: keycloak.nas.svc.h.mirceanton.com
+        port: 443
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/gateway.networking.k8s.io/backendtlspolicy_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: firefly-keycloak-tls
+spec:
+  targetRefs:
+    - group: gateway.envoyproxy.io
+      kind: Backend
+      name: firefly-keycloak
+  validation:
+    hostname: keycloak.nas.svc.h.mirceanton.com
+    wellKnownCACertificates: System
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: firefly-oidc-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: firefly-oidc-secret
+    creationPolicy: Owner
+
+  data:
+    - secretKey: client-secret
+      remoteRef:
+        # Reusing the existing "sure" Keycloak client rather than
+        # provisioning a dedicated "firefly" one - the Homelab realm's
+        # "sure" client also needs firefly's redirect URI added to its
+        # Valid Redirect URIs list for this to work.
+        key: "Sure - Keycloak"
+        property: keycloak_client_secret
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: firefly-oidc
+spec:
+  # Only the main app route - not firefly-importer, which keeps its own
+  # separate access story for now.
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: firefly-home
+
+  # Stage 1: log in against Keycloak and forward the access token upstream
+  # via the standard Authorization: Bearer header. NOTE: forwardIDToken looks
+  # like the more obvious fit here, but it's a known-broken no-op in Envoy
+  # Gateway v1.8.x (https://github.com/envoyproxy/gateway/issues/9082) - it
+  # only forwards Envoy's own opaque session cookie, never a real JWT. The
+  # access token, forwarded via the older/stable Authorization-header path,
+  # actually works.
+  oidc:
+    provider:
+      issuer: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+      # Explicit endpoints so the envoy-gateway controller skips its own
+      # OIDC discovery fetch (.well-known/openid-configuration) - see
+      # components/oidc/security-policy.yaml for why.
+      authorizationEndpoint: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab/protocol/openid-connect/auth
+      tokenEndpoint: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab/protocol/openid-connect/token
+      backendRefs:
+        - group: gateway.envoyproxy.io
+          kind: Backend
+          name: firefly-keycloak
+          port: 443
+    clientID: sure
+    clientSecret:
+      name: firefly-oidc-secret
+    scopes: ["openid", "email", "profile"]
+    redirectURL: "https://firefly.home.mirceanton.com/oauth2/callback"
+    logoutPath: "/oauth2/logout"
+    forwardAccessToken: true
+
+  # Stage 2: independently re-verify that access token's signature against
+  # Keycloak's JWKS and extract the "email" claim into Remote-User, which
+  # Firefly is configured (AUTHENTICATION_GUARD*, see helm-release.yaml) to
+  # trust blindly. Envoy overwrites this header on every request - it can't
+  # be spoofed by a client presenting its own Remote-User/Authorization
+  # header, since the claim only ever comes from a signature-verified token.
+  # No audience check: Keycloak access tokens don't reliably carry aud=<client
+  # id> the way ID tokens do unless a dedicated audience mapper is added, and
+  # this policy is already scoped to a single route/issuer.
+  jwt:
+    providers:
+      - name: keycloak
+        issuer: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+        remoteJWKS:
+          uri: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab/protocol/openid-connect/certs
+          backendRefs:
+            - group: gateway.envoyproxy.io
+              kind: Backend
+              name: firefly-keycloak
+              port: 443
+        claimToHeaders:
+          - header: Remote-User
+            claim: email

--- a/apps/finance/firefly/kustomization.yaml
+++ b/apps/finance/firefly/kustomization.yaml
@@ -2,9 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: finance
-
 resources:
-  - ./namespace.yaml
-  - ./firefly
-  - ./sure
+  - ./app.ks.yaml
+  - ./mcp.ks.yaml

--- a/apps/finance/firefly/mcp.ks.yaml
+++ b/apps/finance/firefly/mcp.ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app firefly-mcp
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 5m
+  targetNamespace: finance
+
+  path: ./apps/finance/firefly/mcp
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+
+  dependsOn:
+    - name: firefly
+      namespace: finance

--- a/apps/finance/firefly/mcp/helm-release.yaml
+++ b/apps/finance/firefly/mcp/helm-release.yaml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: firefly-mcp
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: firefly-mcp
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      firefly-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/daften/fireflyiii-mcp
+              tag: 0.3.4
+            env:
+              # PAT-only HTTP mode: the token is forwarded by litellm as a
+              # Bearer header (see apps/ai/litellm/app/files/config.yaml),
+              # not configured here.
+              FIREFLY_URL: "http://firefly:8080"
+
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 5
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 3000
+                  failureThreshold: 30
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: firefly-mcp
+        ports:
+          http:
+            port: 3000
+
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/apps/finance/firefly/mcp/kustomization.yaml
+++ b/apps/finance/firefly/mcp/kustomization.yaml
@@ -2,9 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: finance
-
 resources:
-  - ./namespace.yaml
-  - ./firefly
-  - ./sure
+  - ./oci-repository.yaml
+  - ./helm-release.yaml

--- a/apps/finance/firefly/mcp/oci-repository.yaml
+++ b/apps/finance/firefly/mcp/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: firefly-mcp
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy


### PR DESCRIPTION
## Summary
- Fresh Firefly III deployment in the `finance` namespace (alongside `sure`), using the standard CNPG + VolSync component pattern for the DB and app-data PVC — **not** restoring data from the previously decommissioned instance (old backup data at the same S3 paths was purged so the fresh bootstrap doesn't silently recover it)
- `firefly-mcp` companion server, wired back into LiteLLM's `mcp_servers` config (bearer-token forwarding), pointing at the new `finance` namespace
- SSO via Keycloak (`apps/finance/firefly/app/oidc.yaml`): Firefly has no native OIDC, only trust for a `REMOTE_USER` header from an upstream auth proxy. Implemented as an Envoy Gateway `SecurityPolicy` doing OIDC login (reusing the existing `sure` Keycloak client) + a JWT provider that independently re-verifies the forwarded access token and injects the verified `email` claim into `Remote-User`, which Envoy overwrites on every request (not spoofable by a client-supplied header). `AUTHENTICATION_GUARD=remote_user_guard` — native Firefly password login is disabled as a result. Note: `forwardIDToken` looks like the more obvious mechanism but is a known-broken no-op on the Envoy Gateway version this cluster runs ([envoyproxy/gateway#9082](https://github.com/envoyproxy/gateway/issues/9082)); used `forwardAccessToken` instead.
- Renovate groups/versioning rules and the Homer dashboard tile restored to match

All of the above was already manually applied and tested live against the cluster (fresh DB bootstrap, app, MCP server, and the full Keycloak SSO round-trip all confirmed working) — this PR just brings it into git so Flux can adopt the same objects via server-side apply.

## Manual steps already done for testing (document here for anyone re-running this from scratch)
1. Added `https://firefly.home.mirceanton.com/oauth2/callback` to the `sure` Keycloak client's Valid Redirect URIs (in addition to its existing Sure callback)
2. Registered the first Firefly account (email matches the Keycloak account, so SSO logs into the same user)

## Manual steps still outstanding after this merges and Flux reconciles
1. Generate an OAuth Personal Access Token in Firefly's UI (Profile → OAuth) and store it in the `Firefly MCP` 1Password item (`token` property) so LiteLLM's ExternalSecret can pick it up
2. If using the data-importer, populate the `Firefly Data Importer` 1Password item (`FIREFLY_III_ACCESS_TOKEN`, `LUNCH_FLOW_API_KEY`) — the `firefly-data-importer-token` ExternalSecret won't sync until those exist

## Test plan
- [x] `firefly` and `firefly-mcp` Flux Kustomizations reconcile cleanly (verified via manual apply of the equivalent rendered manifests)
- [x] CNPG cluster bootstraps a fresh empty DB and reaches healthy state
- [x] `https://firefly.home.mirceanton.com` redirects to Keycloak and logs into the existing account
- [ ] After generating a PAT and updating 1Password, `firefly-mcp` responds and LiteLLM's `firefly` MCP server tools are usable