### PR TITLE
feat(talos): configure PodNodeSelector admission plugin

### DIFF
--- a/apps/ai/namespace.yaml
+++ b/apps/ai/namespace.yaml
@@ -5,4 +5,4 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-    scheduler.alpha.kubernetes.io/node-selector: k8s.mirceanton.com/gpu-node=true
+    scheduler.alpha.kubernetes.io/node-selector: k8s.mirceanton.com/remote-node=true

--- a/apps/ai/namespace.yaml
+++ b/apps/ai/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    scheduler.alpha.kubernetes.io/node-selector: k8s.mirceanton.com/gpu-node=true

--- a/apps/github-actions/namespace.yaml
+++ b/apps/github-actions/namespace.yaml
@@ -5,4 +5,4 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-    scheduler.alpha.kubernetes.io/node-selector: k8s.mirceanton.com/gpu-node=true
+    scheduler.alpha.kubernetes.io/node-selector: k8s.mirceanton.com/remote-node=true

--- a/apps/github-actions/namespace.yaml
+++ b/apps/github-actions/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    scheduler.alpha.kubernetes.io/node-selector: k8s.mirceanton.com/gpu-node=true

--- a/talos/patches/admission-control.yaml
+++ b/talos/patches/admission-control.yaml
@@ -1,0 +1,10 @@
+---
+cluster:
+  apiServer:
+    admissionControl:
+      - name: PodSecurity
+        $$patch: delete
+      - name: PodNodeSelector
+        configuration:
+          podNodeSelectorPluginConfig:
+            clusterDefaultNodeSelector: "k8s.mirceanton.com/default-node=true"

--- a/talos/patches/disable-admission-control.yaml
+++ b/talos/patches/disable-admission-control.yaml
@@ -1,5 +1,0 @@
----
-cluster:
-  apiServer:
-    admissionControl:
-      $$patch: delete

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -24,9 +24,9 @@ nodes:
     installDiskSelector: { size: "<= 300Gb" }
     nodeLabels:
       nvidia.com/gpu.present: "true"
-      # TODO: drop once the PN64 controlplane node is added and takes over this label
       k8s.mirceanton.com/default-node: "true"
-      k8s.mirceanton.com/gpu-node: "true"
+      # TODO: drop once the PN64 controlplane node is added and takes over this label
+      k8s.mirceanton.com/remote-node: "true"
 
     networkInterfaces:
       - interface: enp6s0 #? Management

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -24,6 +24,9 @@ nodes:
     installDiskSelector: { size: "<= 300Gb" }
     nodeLabels:
       nvidia.com/gpu.present: "true"
+      # TODO: drop once the PN64 controlplane node is added and takes over this label
+      k8s.mirceanton.com/default-node: "true"
+      k8s.mirceanton.com/gpu-node: "true"
 
     networkInterfaces:
       - interface: enp6s0 #? Management
@@ -86,7 +89,7 @@ controlPlane:
     - "@./patches/network-binding.yaml"
     - "@./patches/mutating-admission.yaml"
     - "@./patches/host-dns.yaml"
-    - "@./patches/disable-admission-control.yaml"
+    - "@./patches/admission-control.yaml"
     - "@./patches/sysctls.yaml"
     - "@./patches/disable-kube-proxy.yaml" #? Cilium CNI
     - "@./patches/registry-mirrors.yaml"


### PR DESCRIPTION
## Summary
- Reconfigure the `admissionControl` patch to add the `PodNodeSelector` plugin (previously it just deleted `PodSecurity` outright; now it deletes only `PodSecurity` and adds `PodNodeSelector`), defaulting all namespaces to `k8s.mirceanton.com/default-node=true`.
- Label the current node with `k8s.mirceanton.com/default-node: "true"` and `k8s.mirceanton.com/gpu-node: "true"` so nothing changes functionally today, since it's still the only node.
- Annotate the `ai` and `github-actions` namespaces with `scheduler.alpha.kubernetes.io/node-selector: k8s.mirceanton.com/gpu-node=true` so local LLM workloads, Renovate, and the GitHub Actions runners are pinned to the GPU/worker-designated node.

This lays the groundwork described in #725. The actual node topology change (adding the PN64 as controlplane, repurposing the current box as the dedicated worker) is deferred to a follow-up PR — at that point, the PN64 gets `default-node=true` and the current box drops that label, completing the split without further changes here.

## Test plan
- [x] `talhelper genconfig --dry-run` — admissionControl renders with `PodSecurity` removed and `PodNodeSelector` configured
- [x] `talosctl validate --mode metal` — generated machine config is valid
- [x] `prettier --check` on all changed files
- [ ] Confirm live `flux reconcile` applies cleanly and existing workloads keep scheduling as before (single node still carries both labels)

Closes #725