### PR TITLE
feat(finance/sure): integrate AI features with LiteLLM

### DIFF
--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -125,6 +125,7 @@ router_settings:
     hermes: qwen3.7-plus
     karakeep: qwen3.6-flash
     karakeep-embeddings: qwen3-embedding-0.6b
+    sure: qwen3.7-plus
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/finance/sure/app/external-secret.yaml
+++ b/apps/finance/sure/app/external-secret.yaml
@@ -50,3 +50,8 @@ spec:
       remoteRef:
         key: Sure - Keys
         property: active_record_encryption_key_derivation_salt
+
+    - secretKey: OPENAI_ACCESS_TOKEN
+      remoteRef:
+        key: Sure - LiteLLM
+        property: password

--- a/apps/finance/sure/app/helm-release.yaml
+++ b/apps/finance/sure/app/helm-release.yaml
@@ -99,6 +99,12 @@ spec:
               EXCHANGE_RATE_PROVIDER: "twelve_data"
               SECURITIES_PROVIDER: "twelve_data"
 
+              # AI assistant + auto-categorization, routed through the LiteLLM
+              # gateway (OPENAI_ACCESS_TOKEN comes from sure-secret via envFrom
+              # above - a LiteLLM virtual key scoped to the "sure" model alias)
+              OPENAI_URI_BASE: "http://litellm.ai.svc.cluster.local:4000/v1"
+              OPENAI_MODEL: "sure"
+
             probes:
               liveness: &probe
                 enabled: true


### PR DESCRIPTION
## Summary
- Routes Sure's AI features (chat assistant + background auto-categorization/merchant detection) through the LiteLLM gateway instead of a direct provider key, using `qwen3.7-plus`
- Adds a `sure` entry to LiteLLM's `router_settings.model_group_alias` (same indirection pattern as `karakeep`/`hermes`, so the underlying model can be swapped later without touching Sure's config)
- `OPENAI_ACCESS_TOKEN` sourced from a new `Sure - LiteLLM` 1Password item (a LiteLLM virtual key scoped to just the `sure` alias), `OPENAI_URI_BASE` points at LiteLLM's in-cluster service, `OPENAI_MODEL=sure`

Already manually applied and tested against the live cluster: verified the `sure` alias resolves correctly and a real `/v1/chat/completions` call through Sure's actual virtual key returns a completion. This PR brings it into git so Flux adopts the same objects.

## Manual steps already done for testing
1. Created a LiteLLM virtual key scoped to the `sure` model group
2. Stored it in the `Sure - LiteLLM` 1Password item (`password` property)

## Test plan
- [x] `sure` model alias resolves to `qwen3.7-plus` in LiteLLM
- [x] `sure-secret` ExternalSecret syncs `OPENAI_ACCESS_TOKEN` from 1Password
- [x] `sure-web` and `sure-worker` roll out cleanly with the new env vars
- [x] End-to-end chat completion call through Sure's virtual key succeeds
- [ ] Chat assistant and auto-categorization verified from within Sure's UI