### PR TITLE
feat(productivity/affine): deploy Affine with Keycloak OIDC and LiteLLM AI

### DIFF
--- a/apps/ai/litellm/app/external-secret.yaml
+++ b/apps/ai/litellm/app/external-secret.yaml
@@ -23,6 +23,7 @@ spec:
         GITHUB_MCP_TOKEN: "{{ .token }}"
         QWEN_KEY: "{{ .QWEN_KEY }}"
         FIREFLY_MCP_TOKEN: "{{ .FIREFLY_MCP_TOKEN }}"
+        AFFINE_MCP_TOKEN: "{{ .AFFINE_MCP_TOKEN }}"
 
   data:
     - secretKey: master-key
@@ -43,6 +44,11 @@ spec:
     - secretKey: FIREFLY_MCP_TOKEN
       remoteRef:
         key: "Firefly MCP"
+        property: token
+
+    - secretKey: AFFINE_MCP_TOKEN
+      remoteRef:
+        key: "Affine MCP"
         property: token
 
   dataFrom:

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -132,6 +132,14 @@ router_settings:
     karakeep: qwen3.6-flash
     karakeep-embeddings: qwen3-embedding-0.6b
 
+    # Affine's built-in AI features hardcode these exact model names per
+    # action (chat, embeddings, etc.) client-side and request them literally
+    # against whatever provider is configured, regardless of the "affine"
+    # alias above. Alias them to real models so those requests resolve.
+    gemini-2.5-flash: qwen3.7-plus
+    claude-sonnet-4: qwen3.7-plus
+    text-embedding-3-large: qwen3-embedding-0.6b
+
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
   store_model_in_db: true

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -97,6 +97,11 @@ mcp_servers:
     auth_type: bearer_token
     auth_value: os.environ/FIREFLY_MCP_TOKEN
 
+  affine:
+    url: "http://affine-mcp.productivity.svc.cluster.local:3000/mcp"
+    auth_type: bearer_token
+    auth_value: os.environ/AFFINE_MCP_TOKEN
+
   kubesearch:
     url: "http://kubesearch-mcp.ai.svc.cluster.local:3000/mcp"
 

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -122,6 +122,7 @@ mcp_servers:
 
 router_settings:
   model_group_alias:
+    affine: qwen3.7-plus
     hermes: qwen3.7-plus
     karakeep: qwen3.6-flash
     karakeep-embeddings: qwen3-embedding-0.6b

--- a/apps/ai/litellm/app/files/config.yaml
+++ b/apps/ai/litellm/app/files/config.yaml
@@ -137,8 +137,16 @@ router_settings:
     # against whatever provider is configured, regardless of the "affine"
     # alias above. Alias them to real models so those requests resolve.
     gemini-2.5-flash: qwen3.7-plus
+    gemini-embedding-001: qwen3-embedding-0.6b
     claude-sonnet-4: qwen3.7-plus
     text-embedding-3-large: qwen3-embedding-0.6b
+
+    # Explicit "openai"-typed copilot profile (config.json copilot.providers.profiles)
+    # uses these well-known names so Affine's native model catalog recognizes
+    # them without needing the gemini detour above.
+    gpt-4o: qwen3.7-plus
+    gpt-4o-mini: qwen3.7-plus
+    text-embedding-3-small: qwen3-embedding-0.6b
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/ai/litellm/app/helm-release.yaml
+++ b/apps/ai/litellm/app/helm-release.yaml
@@ -69,6 +69,11 @@ spec:
                   secretKeyRef:
                     name: litellm-secret
                     key: FIREFLY_MCP_TOKEN
+              AFFINE_MCP_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-secret
+                    key: AFFINE_MCP_TOKEN
               QWEN_KEY:
                 valueFrom:
                   secretKeyRef:

--- a/apps/productivity/affine/app.ks.yaml
+++ b/apps/productivity/affine/app.ks.yaml
@@ -29,7 +29,8 @@ spec:
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"
       KEYCLOAK_CLIENT_REDIRECT_URL: "https://notes.home.mirceanton.com/*"
-      KEYCLOAK_CLIENT_WEBORIGIN: "https://notes.home.mirceanton.com"
+      KEYCLOAK_CLIENT_WEB_ORIGIN: "https://notes.home.mirceanton.com"
+      KEYCLOAK_CLIENT_HOME_URL: "https://notes.home.mirceanton.com"
       # Affine's BullMQ queues (doc, indexer, copilot, etc.) each select a
       # different logical redis DB index; the shared dragonfly component
       # otherwise defaults to a single DB.
@@ -47,5 +48,5 @@ spec:
       namespace: database-system
     - name: dragonfly-operator
       namespace: database-system
-    - name: keycloak-operator
+    - name: keycloak-operator-config
       namespace: security-system

--- a/apps/productivity/affine/app.ks.yaml
+++ b/apps/productivity/affine/app.ks.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app affine
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: productivity
+
+  path: ./apps/productivity/affine/app
+  components:
+    - ../../../../components/cnpg/
+    - ../../../../components/volsync/
+    - ../../../../components/dragonfly/
+    - ../../../../components/keycloak-client/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+      KEYCLOAK_CLIENT_REDIRECT_URL: "https://notes.home.mirceanton.com/*"
+      KEYCLOAK_CLIENT_WEBORIGIN: "https://notes.home.mirceanton.com"
+      # Affine's BullMQ queues (doc, indexer, copilot, etc.) each select a
+      # different logical redis DB index; the shared dragonfly component
+      # otherwise defaults to a single DB.
+      DRAGONFLY_DBNUM: "16"
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: cloudnative-pg-plugins
+      namespace: database-system
+    - name: dragonfly-operator
+      namespace: database-system
+    - name: keycloak-operator
+      namespace: security-system

--- a/apps/productivity/affine/app/external-secret.yaml
+++ b/apps/productivity/affine/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name affine-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    - secretKey: LITELLM_API_KEY
+      remoteRef:
+        key: Affine - LiteLLM
+        property: password

--- a/apps/productivity/affine/app/external-secret.yaml
+++ b/apps/productivity/affine/app/external-secret.yaml
@@ -20,3 +20,13 @@ spec:
       remoteRef:
         key: Affine - LiteLLM
         property: password
+
+    - secretKey: MAILER_USER
+      remoteRef:
+        key: Affine - SMTP
+        property: username
+
+    - secretKey: MAILER_PASSWORD
+      remoteRef:
+        key: Affine - SMTP
+        property: password

--- a/apps/productivity/affine/app/files/config.json
+++ b/apps/productivity/affine/app/files/config.json
@@ -23,7 +23,8 @@
     "enabled": true,
     "byok": {
       "enabled": true,
-      "allowCustomEndpoint": true
+      "allowCustomEndpoint": true,
+      "allowPrivateEndpoint": true
     },
     "providers": {
       "openai": {

--- a/apps/productivity/affine/app/files/config.json
+++ b/apps/productivity/affine/app/files/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://github.com/toeverything/affine/releases/latest/download/config.schema.json",
   "server": {
-    "name": "AFFiNE",
+    "name": "Self-Hosted",
     "externalUrl": "https://notes.home.mirceanton.com"
   },
   "flags": {

--- a/apps/productivity/affine/app/files/config.json
+++ b/apps/productivity/affine/app/files/config.json
@@ -28,6 +28,9 @@
     "providers": {
       "openai": {
         "baseURL": "http://litellm.ai.svc.cluster.local:4000/v1"
+      },
+      "gemini": {
+        "baseURL": "http://litellm.ai.svc.cluster.local:4000/v1beta"
       }
     }
   }

--- a/apps/productivity/affine/app/files/config.json
+++ b/apps/productivity/affine/app/files/config.json
@@ -4,6 +4,9 @@
     "name": "AFFiNE",
     "externalUrl": "https://notes.home.mirceanton.com"
   },
+  "flags": {
+    "allowGuestDemoWorkspace": false
+  },
   "oauth": {
     "providers": {
       "oidc": {

--- a/apps/productivity/affine/app/files/config.json
+++ b/apps/productivity/affine/app/files/config.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://github.com/toeverything/affine/releases/latest/download/config.schema.json",
+  "server": {
+    "name": "AFFiNE",
+    "externalUrl": "https://notes.home.mirceanton.com"
+  },
+  "oauth": {
+    "providers": {
+      "oidc": {
+        "clientId": "affine",
+        "issuer": "https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab",
+        "allowPrivateNetwork": true,
+        "args": {
+          "scope": "openid profile email"
+        }
+      }
+    }
+  },
+  "copilot": {
+    "enabled": true,
+    "byok": {
+      "enabled": true,
+      "allowCustomEndpoint": true
+    },
+    "providers": {
+      "openai": {
+        "baseURL": "http://litellm.ai.svc.cluster.local:4000/v1"
+      }
+    }
+  }
+}

--- a/apps/productivity/affine/app/files/config.json
+++ b/apps/productivity/affine/app/files/config.json
@@ -31,6 +31,25 @@
       },
       "gemini": {
         "baseURL": "http://litellm.ai.svc.cluster.local:4000/v1beta"
+      },
+      "profiles": [
+        {
+          "id": "litellm",
+          "displayName": "Self-Hosted (LiteLLM)",
+          "type": "openai",
+          "priority": 100,
+          "models": ["gpt-4o", "gpt-4o-mini", "text-embedding-3-small"],
+          "config": {
+            "baseURL": "http://litellm.ai.svc.cluster.local:4000/v1"
+          }
+        }
+      ],
+      "defaults": {
+        "text": "litellm",
+        "object": "litellm",
+        "embedding": "litellm",
+        "rerank": "litellm",
+        "fallback": "litellm"
       }
     }
   }

--- a/apps/productivity/affine/app/helm-release.yaml
+++ b/apps/productivity/affine/app/helm-release.yaml
@@ -1,0 +1,210 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app affine
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: affine
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      affine:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.6.0
+            args: ["postgresql", "$(DB_URL)"]
+            env:
+              DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: affine-postgres-app
+                    key: uri
+
+          wait-for-dragonfly:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.6.0
+            args: ["redis", "redis://affine-dragonfly:6379"]
+
+          render-config:
+            image:
+              repository: docker.io/mikefarah/yq
+              tag: "4"
+            command:
+              - sh
+              - -c
+              - |
+                set -euo pipefail
+                yq -o=json \
+                  '.oauth.providers.oidc.clientSecret = env(OIDC_CLIENT_SECRET) | .copilot.providers.openai.apiKey = env(LITELLM_API_KEY)' \
+                  /tmp/config.json > /home/affine/.affine/config/config.json
+            env:
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: affine-oidc-secret
+                    key: client-secret
+              LITELLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: affine-secret
+                    key: LITELLM_API_KEY
+
+          migrate:
+            image:
+              repository: ghcr.io/toeverything/affine
+              tag: &tag "0.27.3"
+            command: ["sh", "-c"]
+            args: ["node ./scripts/self-host-predeploy.js"]
+            env: &appEnv
+              HOME: /home/affine
+              REDIS_SERVER_HOST: affine-dragonfly
+              AFFINE_INDEXER_ENABLED: "false"
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef: { name: affine-postgres-app, key: uri }
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/toeverything/affine
+              tag: *tag
+
+            env:
+              <<: *appEnv
+              TZ: "Europe/Bucharest"
+              AFFINE_SERVER_HOST: "notes.home.mirceanton.com"
+              AFFINE_SERVER_HTTPS: "true"
+              AFFINE_SERVER_EXTERNAL_URL: "https://notes.home.mirceanton.com"
+              AFFINE_SERVER_PORT: &port 3010
+              LISTEN_ADDR: "0.0.0.0"
+
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  periodSeconds: 5
+                  failureThreshold: 60
+
+            resources:
+              requests:
+                cpu: 25m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      app:
+        controller: affine
+        ports:
+          http:
+            port: *port
+
+    route:
+      home:
+        hostnames: ["notes.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      home:
+        type: emptyDir
+        advancedMounts:
+          affine:
+            app:
+              - path: /home/affine
+            migrate:
+              - path: /home/affine
+
+      data:
+        existingClaim: ${APP}
+        advancedMounts:
+          affine:
+            app:
+              - path: /home/affine/.affine/storage
+            migrate:
+              - path: /home/affine/.affine/storage
+
+      config:
+        type: emptyDir
+        advancedMounts:
+          affine:
+            app:
+              - path: /home/affine/.affine/config
+            migrate:
+              - path: /home/affine/.affine/config
+            render-config:
+              - path: /home/affine/.affine/config
+
+      config-template:
+        type: configMap
+        name: affine-config-template
+        defaultMode: 0444
+        advancedMounts:
+          affine:
+            render-config:
+              - path: /tmp/config.json
+                subPath: config.json
+
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          affine:
+            app:
+              - path: /tmp
+            migrate:
+              - path: /tmp
+
+      # NestJS GraphQL writes its generated schema here on boot.
+      app-src:
+        type: emptyDir
+        advancedMounts:
+          affine:
+            app:
+              - path: /app/src
+            migrate:
+              - path: /app/src

--- a/apps/productivity/affine/app/helm-release.yaml
+++ b/apps/productivity/affine/app/helm-release.yaml
@@ -59,7 +59,7 @@ spec:
               - |
                 set -euo pipefail
                 yq -o=json \
-                  '.oauth.providers.oidc.clientSecret = env(OIDC_CLIENT_SECRET) | .copilot.providers.openai.apiKey = env(LITELLM_API_KEY)' \
+                  '.oauth.providers.oidc.clientSecret = env(OIDC_CLIENT_SECRET) | .copilot.providers.openai.apiKey = env(LITELLM_API_KEY) | .copilot.providers.gemini.apiKey = env(LITELLM_API_KEY)' \
                   /tmp/config.json > /home/affine/.affine/config/config.json
             env:
               OIDC_CLIENT_SECRET:

--- a/apps/productivity/affine/app/helm-release.yaml
+++ b/apps/productivity/affine/app/helm-release.yaml
@@ -102,6 +102,18 @@ spec:
               AFFINE_SERVER_PORT: &port 3010
               LISTEN_ADDR: "0.0.0.0"
 
+              MAILER_HOST: "smtp.migadu.com"
+              MAILER_PORT: "465"
+              MAILER_USER:
+                valueFrom:
+                  secretKeyRef: { name: affine-secret, key: MAILER_USER }
+              MAILER_PASSWORD:
+                valueFrom:
+                  secretKeyRef: { name: affine-secret, key: MAILER_PASSWORD }
+              MAILER_SENDER:
+                valueFrom:
+                  secretKeyRef: { name: affine-secret, key: MAILER_USER }
+
             probes:
               liveness: &probe
                 enabled: true

--- a/apps/productivity/affine/app/helm-release.yaml
+++ b/apps/productivity/affine/app/helm-release.yaml
@@ -59,7 +59,7 @@ spec:
               - |
                 set -euo pipefail
                 yq -o=json \
-                  '.oauth.providers.oidc.clientSecret = env(OIDC_CLIENT_SECRET) | .copilot.providers.openai.apiKey = env(LITELLM_API_KEY) | .copilot.providers.gemini.apiKey = env(LITELLM_API_KEY)' \
+                  '.oauth.providers.oidc.clientSecret = env(OIDC_CLIENT_SECRET) | .copilot.providers.openai.apiKey = env(LITELLM_API_KEY) | .copilot.providers.gemini.apiKey = env(LITELLM_API_KEY) | .copilot.providers.profiles[0].config.apiKey = env(LITELLM_API_KEY)' \
                   /tmp/config.json > /home/affine/.affine/config/config.json
             env:
               OIDC_CLIENT_SECRET:

--- a/apps/productivity/affine/app/kustomization.yaml
+++ b/apps/productivity/affine/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml
+
+patchesStrategicMerge:
+  - ./patches/cnpg.yaml
+
+configMapGenerator:
+  - name: affine-config-template
+    files:
+      - config.json=./files/config.json
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/apps/productivity/affine/app/oci-repository.yaml
+++ b/apps/productivity/affine/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: affine
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/productivity/affine/app/patches/cnpg.yaml
+++ b/apps/productivity/affine/app/patches/cnpg.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ${APP}-postgres
+spec:
+  postgresql:
+    extensions:
+      - name: vector
+        image:
+          # renovate: suite=trixie-pgdg depName=postgresql-18-pgvector
+          reference: ghcr.io/cloudnative-pg/pgvector:0.8.1-202602120909-18-trixie
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/postgresql.cnpg.io/database_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: ${APP}
+spec:
+  extensions:
+    - name: vector

--- a/apps/productivity/affine/kustomization.yaml
+++ b/apps/productivity/affine/kustomization.yaml
@@ -2,9 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: productivity
-
 resources:
-  - ./namespace.yaml
-  - ./affine
-  - ./vikunja
+  - ./app.ks.yaml

--- a/apps/productivity/affine/mcp.ks.yaml
+++ b/apps/productivity/affine/mcp.ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app affine-mcp
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 5m
+  targetNamespace: productivity
+
+  path: ./apps/productivity/affine/mcp
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: affine
+      namespace: productivity

--- a/apps/productivity/affine/mcp/external-secret.yaml
+++ b/apps/productivity/affine/mcp/external-secret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name affine-mcp-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    # Shared bearer token: litellm forwards this as the Authorization header
+    # when calling the MCP server (see apps/ai/litellm/app/files/config.yaml).
+    - secretKey: AFFINE_MCP_HTTP_TOKEN
+      remoteRef:
+        key: "Affine MCP"
+        property: token
+
+    # Dedicated local Affine account the MCP server logs in as. Affine's
+    # native personal-access-token API was removed in 0.27+, and OIDC-
+    # provisioned accounts have no local password, so this has to be a
+    # local email+password account created via Admin Panel -> Accounts.
+    - secretKey: AFFINE_EMAIL
+      remoteRef:
+        key: "Affine - MCP Service Account"
+        property: username
+
+    - secretKey: AFFINE_PASSWORD
+      remoteRef:
+        key: "Affine - MCP Service Account"
+        property: password

--- a/apps/productivity/affine/mcp/helm-release.yaml
+++ b/apps/productivity/affine/mcp/helm-release.yaml
@@ -1,0 +1,114 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: affine-mcp
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: affine-mcp
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      affine-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dawncr0w/affine-mcp-server
+              tag: "3.0.1"
+            env:
+              MCP_TRANSPORT: http
+              PORT: "3000"
+              AFFINE_MCP_HTTP_HOST: "0.0.0.0"
+              AFFINE_MCP_AUTH_MODE: bearer
+              AFFINE_BASE_URL: "http://affine.productivity.svc.cluster.local:3010"
+              # cluster-internal traffic only, never leaves the pod network
+              AFFINE_ALLOW_INSECURE_HTTP: "true"
+              AFFINE_MCP_HTTP_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: affine-mcp-secret
+                    key: AFFINE_MCP_HTTP_TOKEN
+              AFFINE_EMAIL:
+                valueFrom:
+                  secretKeyRef:
+                    name: affine-mcp-secret
+                    key: AFFINE_EMAIL
+              AFFINE_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: affine-mcp-secret
+                    key: AFFINE_PASSWORD
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 3000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: affine-mcp
+        ports:
+          http:
+            port: 3000
+
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/apps/productivity/affine/mcp/kustomization.yaml
+++ b/apps/productivity/affine/mcp/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./app.ks.yaml
-  - ./mcp.ks.yaml
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/productivity/affine/mcp/oci-repository.yaml
+++ b/apps/productivity/affine/mcp/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: affine-mcp
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/components/dragonfly/dragonfly.yaml
+++ b/components/dragonfly/dragonfly.yaml
@@ -19,7 +19,7 @@ spec:
     - "--bind=::"
     - "--admin_bind=::"
     - --maxmemory=$(MAX_MEMORY)Mi
-    - --dbnum=1
+    - --dbnum=${DRAGONFLY_DBNUM:=1}
     - --dbfilename=dump
     - --proactor_threads=${DRAGONFLY_PROACTOR_THREADS:=1}
     - --cluster_mode=${DRAGONFLY_CLUSTER_MODE:=emulated}


### PR DESCRIPTION
## Summary
- Deploy [Affine](https://affine.pro) as an Outline alternative, mirroring Outline's shared-component setup: CNPG postgres, dragonfly redis, and volsync-backed local blob storage.
- Postgres gets the `pgvector` extension via CNPG's image-volume extensions mechanism (same pattern as Immich), since Affine requires it unconditionally for its schema migrations.
- OIDC login via the declarative `keycloak-client` component (`KeycloakClient` CR), pointed at the `Homelab` realm.
- SMTP configured against an existing Migadu mailbox, so workspace invites/notifications work.
- Disabled `flags.allowGuestDemoWorkspace` so unauthenticated visitors land on `/sign-in` instead of a local browser-only demo workspace.
- Deploy [`affine-mcp-server`](https://github.com/DAWNCR0W/affine-mcp-server) alongside the app and wire it into LiteLLM's `mcp_servers`, so the AI assistant can read/search/create docs directly. Needs its own local email+password service account (Affine removed native PATs in 0.27+, and OIDC-provisioned accounts have no local password).
- **AI/Copilot**: routes through LiteLLM's OpenAI-compatible endpoint, plus a `gemini` provider pointed at LiteLLM's Gemini-compatible surface. This turned out to be load-bearing, not cosmetic — see below.

### The copilot model resolution rabbit hole
Affine's built-in AI actions (chat, writing tools, etc.) hardcode specific model names per action in a compiled-in prompt catalog (e.g. `gemini-2.5-flash` for the main chat prompt), matched against a **native Rust model registry** keyed to a specific backend kind (`gemini_api`/`gemini_vertex` for that one). This check happens before Affine ever makes an HTTP call — no LiteLLM-side alias, `providers.profiles`, or `providers.defaults` override can bypass it, because none of the built-in prompts omit their model id (the only case where `providers.defaults` is even consulted).

The fix: LiteLLM's proxy also exposes a Gemini-API-compatible surface (`/v1beta/models/{model}:generateContent`) that routes through the same model list/aliases as its OpenAI-compatible endpoint. Pointing `copilot.providers.gemini.baseURL` at it satisfies Affine's native check while still resolving to our real self-hosted models.

Also added an explicit `openai`-typed BYOK profile (`gpt-4o`/`gpt-4o-mini`/`text-embedding-3-small` aliases) — confirmed this doesn't affect the in-chat model picker (which switches between fixed prompts, not free model selection) but is there for the separate Workspace Settings → AI BYOK screen.

**Known remaining gap**: Affine's embedding background job hardcodes `gemini-embedding-001` and always passes it explicitly, same as chat — but LiteLLM's Gemini-compatible surface only implements `:generateContent`, not `:embedContent` (confirmed via direct curl, plain 404). No config-level fix exists; affects workspace semantic search only, not chat/writing actions. Left as-is per discussion — either needs a real Google API key scoped to just that model, or upstream LiteLLM support for the missing route.

Also fixed three latent bugs surfaced while wiring this up in shared components:
- `keycloak-client`: `redirectUris`/`webOrigins` were invalid YAML (quotes wrapped only the default value instead of the whole `${VAR:-default}` expression); `webOrigins` had no override variable.
- `dragonfly`: `--dbnum` was hardcoded to `1`. Affine's BullMQ queues need multiple redis DB indices, so this needed to be overridable (`DRAGONFLY_DBNUM`).

## Test plan
- [x] Applied manifests directly to the cluster and validated live at every step: postgres cluster bootstraps healthy with the `vector` extension, dragonfly comes up with 16 DBs, OIDC login works end-to-end through a real browser session against Keycloak, `affine-mcp-server` authenticates and serves 92 tools via LiteLLM.
- [x] Confirmed AI chat works: Affine's logs show `Copilot provider candidate found: gemini (gemini-default)` (previously `NO_COPILOT_PROVIDER_AVAILABLE`), with live session activity and no downstream errors.
- [x] Confirmed the LiteLLM Gemini-compatible endpoint resolves correctly via direct curl before wiring it into Affine.
- [ ] After merge: run `flux resume kustomization litellm -n ai` (suspended during testing so direct `kubectl apply` validation wouldn't get reverted by Flux reconciling the unmerged `litellm` changes back to `main`).