### PR TITLE
feat(keep): deploy Anchor as a Google Keep alternative

### DIFF
--- a/apps/productivity/keep/app.ks.yaml
+++ b/apps/productivity/keep/app.ks.yaml
@@ -25,9 +25,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-      KEYCLOAK_CLIENT_REDIRECT_URL: "https://keep.home.mirceanton.com/*"
-      KEYCLOAK_CLIENT_WEB_ORIGIN: "https://keep.home.mirceanton.com"
-      KEYCLOAK_CLIENT_HOME_URL: "https://keep.home.mirceanton.com"
 
   decryption: { provider: sops }
   dependsOn:

--- a/apps/productivity/keep/app.ks.yaml
+++ b/apps/productivity/keep/app.ks.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app keep
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: productivity
+
+  path: ./apps/productivity/keep/app
+  components:
+    - ../../../../components/cnpg/
+    - ../../../../components/volsync/
+    - ../../../../components/keycloak-client/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      KEYCLOAK_CLIENT_REDIRECT_URL: "https://keep.home.mirceanton.com/*"
+      KEYCLOAK_CLIENT_WEB_ORIGIN: "https://keep.home.mirceanton.com"
+      KEYCLOAK_CLIENT_HOME_URL: "https://keep.home.mirceanton.com"
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: cloudnative-pg-plugins
+      namespace: database-system
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/productivity/keep/app/external-secret.yaml
+++ b/apps/productivity/keep/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name keep-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    - secretKey: JWT_SECRET
+      remoteRef:
+        key: Anchor - Keys
+        property: jwt_secret

--- a/apps/productivity/keep/app/helm-release.yaml
+++ b/apps/productivity/keep/app/helm-release.yaml
@@ -36,7 +36,7 @@ spec:
           app:
             image:
               repository: ghcr.io/zhfahim/anchor
-              tag: v0.14.0
+              tag: 0.14.0
 
             envFrom:
               - secretRef: { name: keep-secret }

--- a/apps/productivity/keep/app/helm-release.yaml
+++ b/apps/productivity/keep/app/helm-release.yaml
@@ -1,0 +1,166 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keep
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: keep
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      keep:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.6.0
+            args: ["postgresql", "$(DB_URL)"]
+            env:
+              DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-postgres-app
+                    key: uri
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/zhfahim/anchor
+              tag: v0.14.0
+
+            envFrom:
+              - secretRef: { name: keep-secret }
+            env:
+              # Application
+              APP_URL: "https://keep.home.mirceanton.com"
+              DATA_DIR: /data
+              CORS_ORIGINS: "https://keep.home.mirceanton.com"
+              USER_SIGNUP: disabled
+              # Authentication
+              DISABLE_INTERNAL_AUTH: "true"
+              OIDC_ENABLED: "true"
+              OIDC_PROVIDER_NAME: "Keycloak"
+              OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+              OIDC_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-oidc-secret
+                    key: client-id
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-oidc-secret
+                    key: client-secret
+              # Postgres
+              PG_HOST:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-postgres-app
+                    key: host
+              PG_PORT:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-postgres-app
+                    key: port
+              PG_DATABASE:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-postgres-app
+                    key: dbname
+              PG_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-postgres-app
+                    key: username
+              PG_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: keep-postgres-app
+                    key: password
+
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: &port 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  periodSeconds: 5
+                  failureThreshold: 30
+
+            # The upstream image bundles postgres:18-alpine as its base and
+            # supervisord.conf hardcodes `user=root` for process management,
+            # so the container cannot run as a non-root user even though we
+            # point it at an external CNPG cluster instead of the embedded one.
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile: { type: RuntimeDefault }
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+
+    route:
+      home:
+        hostnames: ["keep.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      data:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run

--- a/apps/productivity/keep/app/kustomization.yaml
+++ b/apps/productivity/keep/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./helm-release.yaml
+  - ./oci-repository.yaml
+  - ./external-secret.yaml

--- a/apps/productivity/keep/app/oci-repository.yaml
+++ b/apps/productivity/keep/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: keep
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/productivity/keep/kustomization.yaml
+++ b/apps/productivity/keep/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/productivity/kustomization.yaml
+++ b/apps/productivity/kustomization.yaml
@@ -7,4 +7,5 @@ namespace: productivity
 resources:
   - ./namespace.yaml
   - ./affine
+  - ./keep
   - ./vikunja


### PR DESCRIPTION
## Summary
- Deploys [Anchor](https://github.com/zhfahim/anchor) (an offline-first, self-hostable note-taking app) as **Keep** in the `productivity` namespace, exposed at `https://keep.home.mirceanton.com`.
- Backing store is an external CNPG Postgres cluster (`components/cnpg`) — the app supports pointing at an external Postgres via `PG_HOST`, so the image's embedded Postgres is disabled.
- `/data` (uploads + misc app state) is a Volsync-backed PVC (`components/volsync`) with off-site restic backups.
- Auth is handled by a dedicated Keycloak OIDC client (`components/keycloak-client`), created via the `KeycloakClient` CRD; local/internal login is disabled (`DISABLE_INTERNAL_AUTH: "true"`, `USER_SIGNUP: disabled`) so Keycloak is the only way in. The first user to log in via OIDC is automatically promoted to admin.
- Dragonfly is **not** wired up — Anchor has no Redis/cache dependency (confirmed by reading its source), so that component would be dead weight.
- The main container has to run as root: the upstream image bundles `postgres:18-alpine` as its base and its `supervisord.conf` hardcodes `user=root` for process supervision, so even though we bypass the embedded Postgres, the container can't drop to a non-root UID (documented inline in the `HelmRelease`).
- New `keep-secret` ExternalSecret sources `JWT_SECRET` from an `Anchor - Keys` 1Password item (needs to be created before this can deploy, mirroring the `Vikunja - Keys` pattern).

## Test plan
- [x] `prettier --check` on the new/changed files
- [x] YAML syntax validated for all new manifests
- [ ] `flux get kustomization keep` reconciles cleanly once merged
- [ ] Create the `Anchor - Keys` (`jwt_secret`) 1Password item before merge so the `ExternalSecret` can sync
- [ ] Verify OIDC login flow works end-to-end against Keycloak at `keep.home.mirceanton.com`

Closes #758
