### PR TITLE
feat: deploy hermes-alertmanager and forward alerts to it

### DIFF
--- a/apps/ai/hermes-alertmanager/app.ks.yaml
+++ b/apps/ai/hermes-alertmanager/app.ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes-alertmanager
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: ai
+
+  path: ./apps/ai/hermes-alertmanager/app
+  components:
+    - ../../../../components/volsync/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_PUID: "65532"
+      VOLSYNC_PGID: "65532"
+
+  dependsOn:
+    # - name: external-secrets-operator
+    #   namespace: security-system
+    # - name: volsync
+    #   namespace: storage-system

--- a/apps/ai/hermes-alertmanager/app.ks.yaml
+++ b/apps/ai/hermes-alertmanager/app.ks.yaml
@@ -27,7 +27,7 @@ spec:
       VOLSYNC_PGID: "65532"
 
   dependsOn:
-    # - name: external-secrets-operator
-    #   namespace: security-system
-    # - name: volsync
-    #   namespace: storage-system
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system

--- a/apps/ai/hermes-alertmanager/app/helm-release.yaml
+++ b/apps/ai/hermes-alertmanager/app/helm-release.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app hermes-alertmanager
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: hermes-alertmanager
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+
+    controllers:
+      hermes-alertmanager:
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/mirceanton/hermes-alertmanager
+              tag: v0.1.1-amd64
+            env:
+              HERMES_PORT: &port "8080"
+              HERMES_DB_DRIVER: sqlite
+              HERMES_CONFIG_PATH: /data/hermes-alertmanager.db
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 256Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      hermes-alertmanager:
+        ports: { http: { port: *port } }
+
+    route:
+      home:
+        hostnames: ["hermes-alertmanager.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /data

--- a/apps/ai/hermes-alertmanager/app/helm-release.yaml
+++ b/apps/ai/hermes-alertmanager/app/helm-release.yaml
@@ -35,7 +35,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/hermes-alertmanager
-              tag: v0.1.1-amd64
+              tag: v0.1.1
             env:
               HERMES_PORT: &port "8080"
               HERMES_DB_DRIVER: sqlite

--- a/apps/ai/hermes-alertmanager/app/kustomization.yaml
+++ b/apps/ai/hermes-alertmanager/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml

--- a/apps/ai/hermes-alertmanager/app/oci-repository.yaml
+++ b/apps/ai/hermes-alertmanager/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes-alertmanager
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/ai/hermes-alertmanager/kustomization.yaml
+++ b/apps/ai/hermes-alertmanager/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/ai/kustomization.yaml
+++ b/apps/ai/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
   - ./github-mcp
   - ./hermes
+  - ./hermes-alertmanager
   - ./kubesearch-mcp
   - ./litellm
   - ./llmkube

--- a/apps/monitoring-system/kube-prometheus-stack/app/alertmanager-config.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/alertmanager-config.yaml
@@ -12,6 +12,13 @@ spec:
     groupInterval: 5m
     repeatInterval: 12h
     routes:
+      - receiver: hermes-alertmanager
+        continue: true
+        matchers:
+          - name: alertname
+            value: "InfoInhibitor|Watchdog"
+            matchType: "!~"
+
       - receiver: pushover-silent
         matchers:
           - name: alertname
@@ -46,6 +53,10 @@ spec:
 
   receivers:
     - name: "null"
+    - name: hermes-alertmanager
+      webhookConfigs:
+        - url: http://hermes-alertmanager.ai.svc.cluster.local:8080/api/v1/webhook
+          sendResolved: true
     - name: pushover-silent
       pushoverConfigs:
         - userKey:


### PR DESCRIPTION
## Summary
- Deploys [hermes-alertmanager](https://github.com/mirceanton/hermes-alertmanager) in the `ai` namespace (app-template HelmRelease, SQLite on a VolSync-replicated PVC, `hermes-alertmanager.home.mirceanton.com`).
- Adds a webhook receiver + catch-all route in `kube-prometheus-stack`'s `AlertmanagerConfig` so every real alert (excluding synthetic `InfoInhibitor`/`Watchdog`) also reaches it, alongside the existing Pushover routing.
- Dispatch to the Hermes agent itself is intentionally left unconfigured (`HERMES_AGENT_WEBHOOK_URL` unset) — delegation rules can be created from the dashboard, but nothing forwards to Hermes yet. That wiring (Hermes's `platforms.webhook` + `mcp_servers` config) is a separate follow-up.

Both the app manifests and the AlertmanagerConfig change have already been manually applied to the cluster and verified live (Alertmanager reloaded with the new route/receiver; the app's pod is still working through an image-pull issue independent of this PR).

## Test plan
- [x] `kustomize build apps/ai/hermes-alertmanager/app` and `kustomize build apps/ai` build cleanly
- [x] `kubectl apply --dry-run=server` validated the `AlertmanagerConfig` change against the live schema
- [x] Applied to the cluster; confirmed via Alertmanager's `/api/v2/status` that the new route and `hermes-alertmanager` webhook receiver are live
- [ ] Confirm hermes-alertmanager pod comes up healthy (image pull) and starts receiving webhook POSTs

🤖 Generated with [Claude Code](https://claude.com/claude-code)