### PR TITLE
feat(hermes): wire up delegation dispatch to hermes-alertmanager

### DIFF
--- a/apps/ai/hermes-alertmanager/app/external-secret.yaml
+++ b/apps/ai/hermes-alertmanager/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name hermes-alertmanager-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    - secretKey: WEBHOOK_SECRET
+      remoteRef:
+        key: Hermes - Alertmanager Webhook
+        property: secret

--- a/apps/ai/hermes-alertmanager/app/helm-release.yaml
+++ b/apps/ai/hermes-alertmanager/app/helm-release.yaml
@@ -40,6 +40,12 @@ spec:
               HERMES_PORT: &port "8080"
               HERMES_DB_DRIVER: sqlite
               HERMES_CONFIG_PATH: /data/hermes-alertmanager.db
+              HERMES_AGENT_WEBHOOK_URL: http://hermes.ai.svc.cluster.local:8644/webhooks/alertmanager
+              HERMES_AGENT_WEBHOOK_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermes-alertmanager-secret
+                    key: WEBHOOK_SECRET
 
             resources:
               requests:

--- a/apps/ai/hermes-alertmanager/app/kustomization.yaml
+++ b/apps/ai/hermes-alertmanager/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/ai/hermes/app/external-secret.yaml
+++ b/apps/ai/hermes/app/external-secret.yaml
@@ -52,6 +52,11 @@ spec:
         key: Hermes - Discord
         property: discord_alertmanager_channel_id
 
+    - secretKey: WEBHOOK_SECRET
+      remoteRef:
+        key: Hermes - Alertmanager Webhook
+        property: secret
+
     - secretKey: FIREFLY_MCP_TOKEN
       remoteRef:
         key: "Firefly MCP"

--- a/apps/ai/hermes/app/files/config.yaml
+++ b/apps/ai/hermes/app/files/config.yaml
@@ -6,7 +6,37 @@ providers:
     base_url: http://litellm:4000/v1
     api_key: "{{ .LITELLM_API_KEY }}"
 
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      port: 8644
+      secret: "{{ .WEBHOOK_SECRET }}"
+      routes:
+        alertmanager:
+          prompt: |
+            An alert was delegated to you by hermes-alertmanager. Investigate
+            it and, if safe, remediate it. When you're done — whether you
+            fixed it, couldn't, or need to bail — you MUST call the
+            `report_delegation_result` MCP tool with
+            delegation_id="{alert.request_id}", status ("completed" or
+            "failed"), and a concise summary. This is the only way
+            hermes-alertmanager finds out you're done.
+
+            Alert: {alert.name}
+            Severity: {alert.severity}
+            Fingerprint: {alert.fingerprint}
+            Times fired: {alert.notification_count}
+            Labels: {alert.labels}
+            Annotations: {alert.annotations}
+          deliver: discord
+          deliver_extra:
+            chat_id: "{{ .DISCORD_ALERTMANAGER_CHANNEL }}"
+
 mcp_servers:
+  hermes_alertmanager:
+    url: "http://hermes-alertmanager.ai.svc.cluster.local:8080/mcp"
+
   github:
     # github-mcp's own nginx sidecar injects the Authorization header with
     # a live-refreshed GitHub App installation token, so this config never

--- a/apps/ai/hermes/app/helm-release.yaml
+++ b/apps/ai/hermes/app/helm-release.yaml
@@ -88,6 +88,9 @@ spec:
               - containerPort: &dashboard_port 9119
                 name: dashboard
                 protocol: TCP
+              - containerPort: &webhook_port 8644
+                name: webhook
+                protocol: TCP
 
             securityContext:
               allowPrivilegeEscalation: false
@@ -110,6 +113,12 @@ spec:
         ports:
           http:
             port: *dashboard_port
+
+      webhook:
+        controller: hermes
+        ports:
+          http:
+            port: *webhook_port
 
     route:
       dashboard:


### PR DESCRIPTION
## Summary
Closes the loop between `hermes-alertmanager` and `hermes` so the delegation protocol documented in [hermes-alertmanager's README](https://github.com/mirceanton/hermes-alertmanager#delegating-to-hermes) actually works end-to-end, not just alert tracking:

- **hermes**: adds `platforms.webhook` (port `8644`, HMAC-signed route `alertmanager`) with the prompt that instructs the agent to call `report_delegation_result` when done, delivered to Discord (`DISCORD_ALERTMANAGER_CHANNEL`, already provisioned). Registers `hermes-alertmanager` as an MCP server so that callback tool is reachable. Exposes the new webhook port as a ClusterIP `Service` only — no external route, it's cluster-internal traffic from hermes-alertmanager.
- **hermes-alertmanager**: sets `HERMES_AGENT_WEBHOOK_URL`/`HERMES_AGENT_WEBHOOK_SECRET` so matched delegation rules actually dispatch instead of silently no-op'ing (previously left unconfigured on purpose, see #766).
- Both sides read the same HMAC secret via their own `ExternalSecret`, sourced from a new 1Password item (`Hermes - Alertmanager Webhook` / `secret`) that needs to be created before these ExternalSecrets will sync successfully.

## Test plan
- [x] `kustomize build` on both `apps/ai/hermes/app` and `apps/ai/hermes-alertmanager/app` — clean, correct rendering of the new port/service/env/config
- [x] Create the `Hermes - Alertmanager Webhook` 1Password item so both `ExternalSecret`s sync
- [ ] After merge/reconcile: create a delegation rule in hermes-alertmanager's dashboard, confirm a matching alert dispatches (`pending` → `dispatched`) and Hermes calls back via MCP (`dispatched` → `completed`/`failed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)