### PR TITLE
fix(container): update ghcr.io/mirceanton/hermes-alertmanager ( v0.1.1 → v0.2.0 )

### DIFF
--- a/apps/ai/hermes-alertmanager/app/helm-release.yaml
+++ b/apps/ai/hermes-alertmanager/app/helm-release.yaml
@@ -35,7 +35,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/hermes-alertmanager
-              tag: v0.1.1
+              tag: v0.2.0
             env:
               HERMES_PORT: &port "8080"
               HERMES_DB_DRIVER: sqlite


### PR DESCRIPTION
## Summary
Bumps the deployed hermes-alertmanager image to v0.2.0, which adds:
- "Delegate now"/"Retry" buttons on the dashboard for manually dispatching a specific active alert to Hermes without waiting for a rule match
- Rejection of duplicate delegation rules (same matcher set)

## Test plan
- [x] Manually applied to the cluster already; rollout completed cleanly (`ghcr.io/mirceanton/hermes-alertmanager:v0.2.0`, 1/1 Ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)