### PR TITLE
fix(container): update ghcr.io/mirceanton/hermes-alertmanager ( v0.2.0 → v0.3.0 )

### DIFF
--- a/apps/ai/hermes-alertmanager/app/helm-release.yaml
+++ b/apps/ai/hermes-alertmanager/app/helm-release.yaml
@@ -35,7 +35,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/hermes-alertmanager
-              tag: v0.2.0
+              tag: v0.3.0
             env:
               HERMES_PORT: &port "8080"
               HERMES_DB_DRIVER: sqlite


### PR DESCRIPTION
## Summary
Bumps the deployed hermes-alertmanager image to v0.3.0:
- Fixes SQLite `busy_timeout`/`foreign_keys` pragmas silently never applying (the DSN was missing the required `file:` prefix, so the whole `?_pragma=...` string was being used as a literal filename instead)
- Surfaces the agent's full `report_delegation_result` summary in the dashboard/history views as an expandable postmortem (was a 320px truncated tooltip before, easy to miss entirely), and tightens the MCP tool's prompt to explicitly ask for postmortem-style content

## Test plan
- [x] Manually applied to the cluster already; rollout completed cleanly (`ghcr.io/mirceanton/hermes-alertmanager:v0.3.0`, 1/1 Ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)