### PR TITLE
fix(container): update ghcr.io/mirceanton/hermes-alertmanager ( v0.3.0 → v0.4.0 )

### DIFF
--- a/apps/ai/hermes-alertmanager/app/helm-release.yaml
+++ b/apps/ai/hermes-alertmanager/app/helm-release.yaml
@@ -35,7 +35,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/hermes-alertmanager
-              tag: v0.3.0
+              tag: v0.4.0
             env:
               HERMES_PORT: &port "8080"
               HERMES_DB_DRIVER: sqlite


### PR DESCRIPTION
## Summary
Bumps the deployed hermes-alertmanager image to v0.4.0 — a web UI redesign:
- New dashboard homepage (`/`) with at-a-glance stats (open alerts, resolved, sessions dispatched, completed/failed, active rules) and a peek at recent delegations
- Unified Alerts page (`/alerts`): currently-firing at top, resolved/paginated below — replaces the separate Active Alerts + History pages
- New Delegations page (`/delegations`): a log of every alert ever delegated to Hermes, full postmortem summary always visible (no click-to-expand needed)
- Centered header nav instead of pushed to opposite edges
- Keeps existing light/dark (OS-preference) theme support unchanged

## Test plan
- [x] Manually applied to the cluster already; rollout completed cleanly (`ghcr.io/mirceanton/hermes-alertmanager:v0.4.0`, 1/1 Ready)
- [x] Verified all four pages render correctly in both light and dark mode via a local Playwright-driven browser check before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)