### PR TITLE
feat(security): deploy SafeLine WAF in security-system

### DIFF
--- a/apps/security-system/kustomization.yaml
+++ b/apps/security-system/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./1password-connect
   - ./external-secrets-operator
   - ./keycloak-operator
+  - ./safeline-waf

--- a/apps/security-system/safeline-waf/app.ks.yaml
+++ b/apps/security-system/safeline-waf/app.ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app safeline-waf
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: security-system
+
+  path: ./apps/security-system/safeline-waf/app
+  components:
+    - ../../../../components/cnpg/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      CNPG_DATA_STORAGE_SIZE: 2Gi
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: cloudnative-pg-plugins
+      namespace: database-system

--- a/apps/security-system/safeline-waf/app/chaos-deployment.yaml
+++ b/apps/security-system/safeline-waf/app/chaos-deployment.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/apps/deployment_v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP}-chaos
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${APP}
+      app.kubernetes.io/component: chaos
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${APP}
+        app.kubernetes.io/component: chaos
+    spec:
+      containers:
+        - name: chaos
+          image: chaitin/safeline-chaos:9.3.11
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${APP}-postgres-app
+                  key: password
+            - name: DB_ADDR
+              value: postgres://${APP}:$(POSTGRES_PASSWORD)@${APP}-postgres-rw:5432/${APP}?sslmode=disable
+          volumeMounts:
+            - { name: data, mountPath: /app/sock, subPath: resources/sock }
+            - { name: data, mountPath: /app/chaos, subPath: resources/chaos }
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { memory: 256Mi }
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ${APP}

--- a/apps/security-system/safeline-waf/app/detect-deployment.yaml
+++ b/apps/security-system/safeline-waf/app/detect-deployment.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/apps/deployment_v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP}-detect
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${APP}
+      app.kubernetes.io/component: detect
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${APP}
+        app.kubernetes.io/component: detect
+    spec:
+      containers:
+        - name: detect
+          image: chaitin/safeline-detector:9.3.11
+          env:
+            - name: LOG_DIR
+              value: /logs/detector
+          volumeMounts:
+            - { name: data, mountPath: /resources/detector, subPath: resources/detector }
+            - { name: data, mountPath: /logs/detector, subPath: logs/detector }
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests: { cpu: 200m, memory: 512Mi }
+            limits: { memory: 1Gi }
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ${APP}

--- a/apps/security-system/safeline-waf/app/fvm-deployment.yaml
+++ b/apps/security-system/safeline-waf/app/fvm-deployment.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/apps/deployment_v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP}-fvm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${APP}
+      app.kubernetes.io/component: fvm
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${APP}
+        app.kubernetes.io/component: fvm
+    spec:
+      containers:
+        - name: fvm
+          image: chaitin/safeline-fvm:9.3.11
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { memory: 256Mi }

--- a/apps/security-system/safeline-waf/app/http-route.yaml
+++ b/apps/security-system/safeline-waf/app/http-route.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${APP}-mgt
+spec:
+  hostnames: ["waf.admin.mirceanton.com"]
+  parentRefs:
+    - name: envoy-admin
+      namespace: network-system
+  rules:
+    - backendRefs:
+        - name: ${APP}-mgt
+          port: 1443

--- a/apps/security-system/safeline-waf/app/kustomization.yaml
+++ b/apps/security-system/safeline-waf/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./pvc.yaml
+  - ./mgt-deployment.yaml
+  - ./detect-deployment.yaml
+  - ./luigi-deployment.yaml
+  - ./fvm-deployment.yaml
+  - ./chaos-deployment.yaml
+  - ./tengine-deployment.yaml
+  - ./service.yaml
+  - ./http-route.yaml

--- a/apps/security-system/safeline-waf/app/luigi-deployment.yaml
+++ b/apps/security-system/safeline-waf/app/luigi-deployment.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/apps/deployment_v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP}-luigi
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${APP}
+      app.kubernetes.io/component: luigi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${APP}
+        app.kubernetes.io/component: luigi
+    spec:
+      containers:
+        - name: luigi
+          image: chaitin/safeline-luigi:9.3.11
+          env:
+            - name: MGT_IP
+              value: safeline-mgt
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${APP}-postgres-app
+                  key: password
+            - name: LUIGI_PG
+              value: postgres://${APP}:$(POSTGRES_PASSWORD)@${APP}-postgres-rw:5432/${APP}?sslmode=disable
+          volumeMounts:
+            - { name: data, mountPath: /app/data, subPath: resources/luigi }
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits: { memory: 256Mi }
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ${APP}

--- a/apps/security-system/safeline-waf/app/mgt-deployment.yaml
+++ b/apps/security-system/safeline-waf/app/mgt-deployment.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/apps/deployment_v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP}-mgt
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${APP}
+      app.kubernetes.io/component: mgt
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${APP}
+        app.kubernetes.io/component: mgt
+    spec:
+      containers:
+        - name: mgt
+          image: chaitin/safeline-mgt:9.3.11
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${APP}-postgres-app
+                  key: password
+            - name: MGT_PG
+              value: postgres://${APP}:$(POSTGRES_PASSWORD)@${APP}-postgres-rw:5432/${APP}?sslmode=disable
+          ports:
+            - name: https
+              containerPort: 1443
+          readinessProbe:
+            httpGet: { path: /api/open/health, port: 1443, scheme: HTTPS }
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /api/open/health, port: 1443, scheme: HTTPS }
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          volumeMounts:
+            - { name: data, mountPath: /app/data, subPath: resources/mgt }
+            - { name: data, mountPath: /app/log/nginx, subPath: logs/nginx }
+            - { name: data, mountPath: /app/sock, subPath: resources/sock }
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests: { cpu: 100m, memory: 256Mi }
+            limits: { memory: 512Mi }
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ${APP}

--- a/apps/security-system/safeline-waf/app/pvc.yaml
+++ b/apps/security-system/safeline-waf/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${APP}
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  storageClassName: openebs-zfs
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/security-system/safeline-waf/app/service.yaml
+++ b/apps/security-system/safeline-waf/app/service.yaml
@@ -1,0 +1,123 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/core/service_v1.json
+# Headless services named after SafeLine's upstream docker-compose
+# container_names. Several internal calls (e.g. mgt -> fvm, luigi -> detect)
+# use these hostnames hardcoded in the binaries rather than the configurable
+# TCD_*/CHAOS_ADDR env vars, so they must resolve by these exact names
+# regardless of which Pod actually hosts each component. Headless (no
+# ClusterIP) resolves straight to the pod IP, avoiding NAT'd-port
+# restrictions for ports not declared below. publishNotReadyAddresses is
+# required too: without it, a component that isn't Ready yet (e.g. because
+# it's waiting on one of these very DNS names) never gets an Endpoint, so
+# DNS never resolves and it can never become Ready - a deadlock.
+apiVersion: v1
+kind: Service
+metadata:
+  name: safeline-mgt
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: mgt
+  ports:
+    - { name: https, port: 1443 }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: safeline-detector
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: detect
+  ports:
+    - { name: sn, port: 8000 }
+    - { name: stat, port: 8001 }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: safeline-fvm
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: fvm
+  ports:
+    - { name: http, port: 80 }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: safeline-chaos
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: chaos
+  ports:
+    - { name: http, port: 9000 }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: safeline-luigi
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: luigi
+  ports:
+    - { name: http, port: 80 }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: safeline-tengine
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: tengine
+  ports:
+    - { name: http, port: 80 }
+    - { name: https, port: 443 }
+---
+# ClusterIP (not headless) - this one's a real backend target for the
+# HTTPRoute/Envoy Gateway, which needs a stable Service, not pod-IP DNS.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${APP}-mgt
+spec:
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: mgt
+  ports:
+    - name: https
+      port: 1443
+      targetPort: 1443
+      appProtocol: https
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${APP}-tengine
+spec:
+  selector:
+    app.kubernetes.io/name: ${APP}
+    app.kubernetes.io/component: tengine
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443

--- a/apps/security-system/safeline-waf/app/tengine-deployment.yaml
+++ b/apps/security-system/safeline-waf/app/tengine-deployment.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/apps/deployment_v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP}-tengine
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${APP}
+      app.kubernetes.io/component: tengine
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${APP}
+        app.kubernetes.io/component: tengine
+    spec:
+      # Each SafeLine component gets its own Pod: several of them (mgt,
+      # luigi, tengine) independently bind port 80 internally, so sharing a
+      # network namespace between any two of them causes a bind conflict.
+      containers:
+        - name: tengine
+          image: chaitin/safeline-tengine:9.3.11
+          env:
+            # Headless Services named after tengine's upstream container_name
+            # peers (see service.yaml) - resolves to real pod IPs, not a
+            # NAT'd ClusterIP.
+            - name: TCD_MGT_API
+              value: https://safeline-mgt:1443/api/open/publish/server
+            - name: TCD_SNSERVER
+              value: safeline-detector:8000
+            - name: SNSERVER_ADDR
+              value: safeline-detector:8000
+            - name: CHAOS_ADDR
+              value: safeline-chaos
+          ports:
+            - { name: waf-http, containerPort: 80 }
+            - { name: waf-https, containerPort: 443 }
+          volumeMounts:
+            - { name: data, mountPath: /etc/nginx, subPath: resources/nginx }
+            - { name: data, mountPath: /resources/detector, subPath: resources/detector }
+            - { name: data, mountPath: /resources/chaos, subPath: resources/chaos }
+            - { name: data, mountPath: /var/log/nginx, subPath: logs/nginx }
+            - { name: data, mountPath: /usr/local/nginx/cache, subPath: resources/cache }
+            - { name: data, mountPath: /app/sock, subPath: resources/sock }
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            requests: { cpu: 100m, memory: 512Mi }
+            limits: { memory: 2Gi }
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ${APP}

--- a/apps/security-system/safeline-waf/kustomization.yaml
+++ b/apps/security-system/safeline-waf/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml


### PR DESCRIPTION
## Summary

Deploys [SafeLine](https://github.com/chaitin/SafeLine) CE (WAF) into the `security-system` namespace.

SafeLine has no official Kubernetes/Helm support - its only shipped deployment method is a 7-container docker-compose stack (`postgres`, `mgt`, `detect`, `tengine`, `luigi`, `fvm`, `chaos`) that assumes each service gets its own network namespace/IP on a private bridge network, plus a shared Unix-socket bind mount between a few of them. This PR translates that into raw Kubernetes manifests:

- One single-container Deployment per SafeLine component (`mgt`, `detect`, `luigi`, `fvm`, `chaos`, `tengine`). Originally tried bundling several as containers in one Pod to mirror the compose topology more directly, but `mgt`, `luigi`, and `tengine` each independently bind port 80 internally and collided once they shared a network namespace - splitting each into its own Pod was the reliable fix.
- All 6 share one PVC (`openebs-zfs`, RWO) via `subPath` mounts, mirroring the compose file's single bind-mounted `$SAFELINE_DIR` layout. Works fine across separate Pods since this is a single-node cluster.
- Postgres is a CloudNativePG `Cluster` via the repo's existing `components/cnpg/` component instead of the bundled `postgres` container.
- Several internal calls in the SafeLine binaries are hardcoded to the upstream compose `container_name`s (e.g. `mgt` calls `http://safeline-fvm/skynetinfo`) rather than going through the configurable `TCD_*`/`CHAOS_ADDR` env vars. Headless Services named to match (`safeline-mgt`, `safeline-detector`, `safeline-fvm`, `safeline-chaos`, `safeline-luigi`, `safeline-tengine`) resolve these directly to pod IPs. They need `publishNotReadyAddresses: true` - without it, a component waiting on one of these names to resolve can never become Ready, which means it never gets an Endpoint, which means the name never resolves (deadlock).
- `mgt`'s admin console is exposed through the existing `envoy-admin` Gateway at `waf.admin.mirceanton.com`.

## Known follow-up (not fixed in this PR)

`mgt`'s admin API only serves HTTPS with a self-signed certificate that has **no Subject Alternative Names**, so Gateway API's `BackendTLSPolicy` (which requires SAN-based hostname validation) can't be used to let Envoy re-originate TLS to the backend. Reaching the console through the `HTTPRoute` as configured will not present the real app. Options for a follow-up: switch to a `TLSRoute` (passthrough) on a new listener on the shared `envoy-admin` Gateway, or get SafeLine to accept a cert-manager-issued cert instead of generating its own. In the meantime, the console is reachable via `kubectl -n security-system port-forward svc/safeline-waf-mgt 1443:1443`.

`tengine` (the actual WAF/reverse-proxy data plane) is deployed and healthy but not yet configured to protect anything - SafeLine's site/upstream/cert configuration lives in its own Postgres DB via its admin UI/API, not as Kubernetes YAML, so wiring a real app behind it is a separate step done after this merges.

## Test plan

- [x] `task lint:check` (prettier) passes on all new files
- [x] `flux build kustomization` resolves the `components/cnpg/` chain and `${APP}` substitution cleanly
- [x] Manually applied to the live cluster: all 6 component Deployments reach `1/1 Running` and stay stable, CNPG `Cluster` reports `Cluster in healthy state`
- [x] `mgt`'s `/api/open/health` endpoint returns `{"status":"ok"}` when reached directly via its Service
- [x] `HTTPRoute` is `Accepted`/`ResolvedRefs` by Envoy Gateway (console access itself is the known follow-up above)