### PR TITLE
fix(renovate): unblock postUpgradeTasks failing across the org

### DIFF
--- a/apps/github-actions/renovate/jobs/renovate-job.yaml
+++ b/apps/github-actions/renovate/jobs/renovate-job.yaml
@@ -57,10 +57,21 @@ spec:
     - name: renovate-cache
       persistentVolumeClaim:
         claimName: renovate-cache
+    - name: mise-bin
+      image:
+        reference: ghcr.io/jdx/mise:2026.8.3
+        pullPolicy: IfNotPresent
 
   extraVolumeMounts:
     - name: renovate-cache
       mountPath: /tmp/renovate-cache
+    - name: mise-bin
+      # /home/ubuntu/bin is the first entry on PATH and is empty in the base
+      # image, so mounting mise's bin dir there makes `mise` resolvable
+      # without touching PATH or shadowing anything else on it.
+      mountPath: /home/ubuntu/bin
+      subPath: usr/local/bin
+      readOnly: true
 
   secretRef: mr-borboto-auth-token
   webhook:

--- a/apps/github-actions/renovate/jobs/renovate-job.yaml
+++ b/apps/github-actions/renovate/jobs/renovate-job.yaml
@@ -28,7 +28,7 @@ spec:
       value: debug
     - name: RENOVATE_ALLOWED_COMMANDS
       value: |-
-        ["pnpm run bundle", "mise install", "mise lock"]
+        ["pnpm run bundle", "mise install", "mise lock", "helm-docs --chart-search-root=. --log-level=warn", "helm-schema --chart-search-root . --skip-auto-generation required,additionalProperties --append-newline"]
     - name: RENOVATE_ALLOWED_UNSAFE_EXECUTIONS
       value: |-
         ["mise"]


### PR DESCRIPTION
## Summary
- Add `helm-docs`/`helm-schema` to `RENOVATE_ALLOWED_COMMANDS` — these were being rejected by the operator's allowlist, failing `renovate/artifacts` on every helm chart bump PR in `charts-mirror` (6 open PRs affected).
- Mount `ghcr.io/jdx/mise` as an OCI image volume onto `/home/ubuntu/bin` so `mise` is actually resolvable when postUpgradeTasks shell out to it. The renovate image has never bundled a `mise` binary (confirmed empirically against multiple historical image tags, including ones from PRs that landed clean), and postUpgradeTasks commands are raw PATH lookups with no tool provisioning of their own — hence `spawn mise ENOENT` on every mise-manager bump across the org.

## Test plan
- [x] Live-tested the OCI image volume mount in a throwaway pod: `mise --version` and `mise trust` succeed as the actual non-root UID the job runs as.
- [x] Cloned the real failing branch (`mirceanton/model-hub@renovate/aqua-pnpm-pnpm-11.x`) into a pod with the same mount and ran the literal failing command, `mise lock` — succeeded, produced a correct 20-entry lockfile.
- [ ] Confirm the next scheduled bot run clears `renovate/artifacts` on the affected PRs (model-hub #46, Hermano #2, charts-mirror #21/#29/#30/#31/#32/#33, and any future mise-manager bumps).