### PR TITLE
fix(renovate): mount helm-docs/helm-schema via OCI image volumes

### DIFF
--- a/apps/github-actions/renovate/jobs/renovate-job.yaml
+++ b/apps/github-actions/renovate/jobs/renovate-job.yaml
@@ -32,6 +32,12 @@ spec:
     - name: RENOVATE_ALLOWED_UNSAFE_EXECUTIONS
       value: |-
         ["mise"]
+    # helm-docs/helm-schema live in their own OCI image volumes (see below)
+    # outside the base image's default PATH dirs, since neither ships a
+    # conveniently-empty directory to mount into like mise does. Appended
+    # (not prepended) so nothing on the existing PATH gets shadowed.
+    - name: PATH
+      value: "/home/ubuntu/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/tools/helm-docs:/opt/tools/helm-schema"
     - name: DOCKERHUB_USERNAME
       valueFrom:
         secretKeyRef:
@@ -61,6 +67,14 @@ spec:
       image:
         reference: ghcr.io/jdx/mise:2026.8.3
         pullPolicy: IfNotPresent
+    - name: helm-docs-bin
+      image:
+        reference: docker.io/jnorwood/helm-docs:v1.14.2
+        pullPolicy: IfNotPresent
+    - name: helm-schema-bin
+      image:
+        reference: ghcr.io/dadav/helm-schema:v0.23.4
+        pullPolicy: IfNotPresent
 
   extraVolumeMounts:
     - name: renovate-cache
@@ -71,6 +85,15 @@ spec:
       # without touching PATH or shadowing anything else on it.
       mountPath: /home/ubuntu/bin
       subPath: usr/local/bin
+      readOnly: true
+    - name: helm-docs-bin
+      mountPath: /opt/tools/helm-docs
+      subPath: usr/bin
+      readOnly: true
+    - name: helm-schema-bin
+      # helm-schema's binary lives at the image root, so mount the whole
+      # thing (no subPath) rather than trying to isolate a single file.
+      mountPath: /opt/tools/helm-schema
       readOnly: true
 
   secretRef: mr-borboto-auth-token


### PR DESCRIPTION
## Summary
Follow-up to #787. Fixing `allowedCommands` there got `helm-docs`/`helm-schema` past Renovate's allowlist, but the actual next run in charts-mirror hit the exact same failure class as `mise`: `spawn helm-docs ENOENT` / `spawn helm-schema ENOENT`. Neither binary is bundled in the renovate image.

- Mount `docker.io/jnorwood/helm-docs:v1.14.2` (`usr/bin` subPath → `/opt/tools/helm-docs`) and `ghcr.io/dadav/helm-schema:v0.23.4` (binary lives at image root → `/opt/tools/helm-schema`) as OCI image volumes.
- Unlike `mise`, neither has a conveniently-empty PATH directory to land in, so this adds an explicit `PATH` env var — appending the two new dirs after the existing default PATH, not prepending, so nothing already resolvable (e.g. helm-docs's image ships busybox under names like `awk`/`basename`) gets shadowed.

## Test plan
- [x] Combined pod test: `mise`, `helm-docs`, `helm-schema` all resolve and run; sanity-checked `basename`/`awk`/`node` still resolve to the original binaries, not the busybox ones bundled in the helm-docs image.
- [x] Reproduced the literal failing postUpgradeTask commands against the real branch (`charts-mirror@renovate/mlflow-1.x`): both `helm-docs --chart-search-root=. --log-level=warn` and `helm-schema --chart-search-root . --skip-auto-generation required,additionalProperties --append-newline` exit 0.
- [ ] Confirm the next bot run clears `renovate/artifacts` on charts-mirror #21/#29/#30/#31/#32/#33.