### PR TITLE
fix(karakeep): move alpine-chrome off dead gcr.io registry

### DIFF
--- a/apps/media/karakeep/app/karakeep.helm-release.yaml
+++ b/apps/media/karakeep/app/karakeep.helm-release.yaml
@@ -81,7 +81,7 @@ spec:
         containers:
           app:
             image:
-              repository: gcr.io/zenika-hub/alpine-chrome
+              repository: ghcr.io/zenika/alpine-chrome
               tag: "124"
             command:
               - chromium-browser


### PR DESCRIPTION
## Summary
The Dependency Dashboard was flagging: `Failed to look up docker package gcr.io/zenika-hub/alpine-chrome: no-result`.

`gcr.io/zenika-hub/alpine-chrome` now 401s even for anonymous pulls — Google shut down anonymous reads on legacy Container Registry in June 2025, and this particular repo never got migrated to Artifact Registry (unlike Google-owned `gcr.io` images, which did get auto-migrated and keep working).

The same maintainer publishes an identical mirror on GHCR, including this exact `124` tag, so this is a same-version registry swap — not a version bump, no behavior change.

## Test plan
- [x] Confirmed `gcr.io/zenika-hub/alpine-chrome:124` returns 401 (dead)
- [x] Confirmed `ghcr.io/zenika/alpine-chrome:124` resolves (200) and has an identical tag
- [ ] Confirm the Dependency Dashboard warning clears after this merges and Renovate re-scans