### PR TITLE
feat(hermano): enable OIDC / Keycloak SSO

### DIFF
--- a/apps/ai/hermano/app.ks.yaml
+++ b/apps/ai/hermano/app.ks.yaml
@@ -14,6 +14,7 @@ spec:
   path: ./apps/ai/hermano/app
   components:
     - ../../../../components/volsync/
+    - ../../../../components/keycloak-client/
   sourceRef:
     kind: GitRepository
     name: flux-system
@@ -33,3 +34,5 @@ spec:
       namespace: ai
     - name: volsync
       namespace: storage-system
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/ai/hermano/app/helm-release.yaml
+++ b/apps/ai/hermano/app/helm-release.yaml
@@ -54,9 +54,12 @@ spec:
                     name: hermano-secret
                     key: PUSHOVER_USER_KEY
 
+              # Externally-reachable origin, used to build dashboard links
+              # (Pushover's "View in Hermano", OIDC's redirect default)
+              HERMANO_PUBLIC_URL: https://hermano.home.mirceanton.com
+
               # OIDC / Keycloak SSO
               OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
-              OIDC_REDIRECT_URL: https://hermano.home.mirceanton.com/auth/callback
               OIDC_CLIENT_ID:
                 valueFrom:
                   secretKeyRef:

--- a/apps/ai/hermano/app/helm-release.yaml
+++ b/apps/ai/hermano/app/helm-release.yaml
@@ -54,6 +54,25 @@ spec:
                     name: hermano-secret
                     key: PUSHOVER_USER_KEY
 
+              # OIDC / Keycloak SSO
+              OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+              OIDC_REDIRECT_URL: https://hermano.home.mirceanton.com/auth/callback
+              OIDC_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermano-oidc-secret
+                    key: client-id
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermano-oidc-secret
+                    key: client-secret
+              SESSION_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermano-session-secret
+                    key: password
+
             resources:
               requests:
                 cpu: 10m

--- a/apps/ai/hermano/app/kustomization.yaml
+++ b/apps/ai/hermano/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
   - ./external-secret.yaml
+  - ./session-secret.yaml

--- a/apps/ai/hermano/app/session-secret.yaml
+++ b/apps/ai/hermano/app/session-secret.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: hermano-session-secret
+spec:
+  length: 64
+  digits: 10
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name hermano-session-secret
+spec:
+  refreshInterval: "0"
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: hermano-session-secret


### PR DESCRIPTION
## Summary
- Register a Keycloak client for hermano via the `keycloak-client` component (creates `hermano-oidc-secret`)
- Add `OIDC_ISSUER_URL`, `OIDC_REDIRECT_URL`, `OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET`, and a generated `SESSION_SECRET` to the HelmRelease, switching hermano from single-user mode to OIDC login
- Session secret is generated via an External Secrets `Password` generator (no manual 1Password entry required), mirroring the pattern used in `apps/maker/modelhub`

## Test plan
- [ ] Flux reconciles `hermano` Kustomization and `KeycloakClient` successfully
- [ ] `hermano-oidc-secret` and `hermano-session-secret` are created
- [ ] Visiting https://hermano.home.mirceanton.com redirects to Keycloak login
- [ ] Login via Keycloak succeeds and returns to hermano