### PR TITLE
test: downflate/konflate smoke test (do not merge)

### DIFF
--- a/apps/tools/drawio/app/helm-release.yaml
+++ b/apps/tools/drawio/app/helm-release.yaml
@@ -23,7 +23,7 @@ spec:
           app:
             image:
               repository: docker.io/jgraph/drawio
-              tag: 31.1.8
+              tag: 31.1.5
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
## Summary
- Trivial image tag bump (drawio 31.1.8 -> 31.1.5) purely to exercise the new CI triggers
- Verifies downflate pre-pulls the changed image onto the Talos node, and konflate renders the resulting diff

Not intended to be merged.