### PR TITLE
feat(renovate): configure Keycloak OIDC authentication

### DIFF
--- a/apps/github-actions/renovate/operator.ks.yaml
+++ b/apps/github-actions/renovate/operator.ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: renovate-operator
+  name: &app renovate-operator
 spec:
   interval: 10m
   prune: true
@@ -11,7 +11,20 @@ spec:
   targetNamespace: github-actions
 
   path: ./apps/github-actions/renovate/operator
+  components:
+    - ../../../../components/keycloak-client/
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      KEYCLOAK_CLIENT_REDIRECT_URL: "https://renovate.home.mirceanton.com/*"
+      KEYCLOAK_CLIENT_WEB_ORIGIN: "https://renovate.home.mirceanton.com"
+      KEYCLOAK_CLIENT_HOME_URL: "https://renovate.home.mirceanton.com"
+
+  dependsOn:
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/github-actions/renovate/operator/helm-release.yaml
+++ b/apps/github-actions/renovate/operator/helm-release.yaml
@@ -56,8 +56,18 @@ spec:
       level: info
       format: json
 
-    # TODO: keycloak OIDC via Keycloak
-    auth: { oidc: { enabled: false } }
+    auth:
+      oidc:
+        enabled: true
+        issuerUrl: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+        clientId: renovate-operator
+        existingSecret: renovate-operator-oidc-secret
+        # the operator auto-detects its callback URL's scheme from `ingress.tls`,
+        # which is unset here since we route via Gateway API instead of Ingress
+        redirectScheme: https
+
+    # authentication only, no per-job access rules - every authenticated user is an admin
+    authorization: { enabled: false }
 
     webhook: { enabled: false }
     route:


### PR DESCRIPTION
Wires the renovate-operator's native v6 auth.oidc support to Keycloak
via the shared keycloak-client component, authentication only -
authorization.enabled is set to false so every authenticated user
gets admin access, matching the previous no-auth-at-all behavior.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017oT4bpquqdmeL47euounLY