### PR TITLE
fix(monitoring-system): deploy blackbox-exporter

### DIFF
--- a/apps/monitoring-system/kustomization.yaml
+++ b/apps/monitoring-system/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./grafana
 
   # Exporters
+  - ./blackbox-exporter
   - ./ipmi-exporter
   - ./kube-state-metrics
   - ./mikrotik-exporter


### PR DESCRIPTION
## Summary
- The `apps/monitoring-system/blackbox-exporter/` directory (HelmRelease, probes, Grafana dashboard) was fully built out but never listed in `apps/monitoring-system/kustomization.yaml`'s `resources`, so Flux was never applying it.
- Adds `./blackbox-exporter` to the resources list, matching the "Common Pitfalls" warning in `.agents/skills/deploy-app.md` about namespace-level kustomizations being the source of truth.

## Test plan
- [ ] `task lint:check` passes
- [ ] `kustomize build apps/monitoring-system` renders the blackbox-exporter resources without error
- [ ] Flux reconciles and `blackbox-exporter` pod comes up healthy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQr1Tn2MSvRei8pAQnMPfc)_