### PR TITLE
fix(flate): correct PR path filter to match this repo's layout

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["main"]
-    paths: ["apps/**", "talos/**", "components/**", "bootstrap/**"]
+    paths: ["apps/**", "components/**", "bootstrap/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["main"]
-    paths: ["kubernetes/**"]
+    paths: ["apps/**", "talos/**", "components/**", "bootstrap/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}


### PR DESCRIPTION
## Summary
- `.github/workflows/flate.yaml` filtered `pull_request` triggers on `paths: ["kubernetes/**"]`, but this repo has no `kubernetes/` directory — manifests live under `apps/`, `talos/`, `components/`, and `bootstrap/`. Looks like a leftover from a template with a different layout.
- Since a non-matching `paths:` filter means the workflow is skipped entirely, the `downflate`/`konflate` PR-preview jobs effectively never fired on `pull_request`.
- Updates the filter to `["apps/**", "talos/**", "components/**", "bootstrap/**"]`.

## Test plan
- [ ] Open a PR touching a file under `apps/` and confirm the Flate workflow triggers

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQr1Tn2MSvRei8pAQnMPfc)_