### PR TITLE
docs(agents): remove dead link to nonexistent CNPG migration skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,6 @@
 ## Skills
 
 - **Deploy a new app**: `.agents/skills/deploy-app.md` — adds a new application to the cluster using the bjw-s-labs app-template chart.
-- **Migrate a CNPG cluster**: `.agents/skills/migrate-cnpg-cluster.md` — moves a Postgres cluster's data to a new namespace/name via backup → redeploy → recover (no in-place migration or auto-restore exists in CNPG).
 - **Unlock a stuck VolSync backup**: `.agents/skills/volsync-unlock.md` — clears a stale restic repo lock (usually from apiserver flakiness killing the mover pod mid-`forget`) that otherwise loops backup Jobs forever.
 
 ## Critical Operational Notes


### PR DESCRIPTION
## Summary
- `AGENTS.md` documented `.agents/skills/migrate-cnpg-cluster.md` as one of three skills, but `.agents/skills/` only contains `deploy-app.md` and `volsync-unlock.md`.
- Removes the dead bullet so agents/readers aren't sent looking for a runbook that isn't there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQr1Tn2MSvRei8pAQnMPfc)_