### PR TITLE
fix(development): use the standard namespace.yaml placeholder

### DIFF
--- a/apps/development/namespace.yaml
+++ b/apps/development/namespace.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: development
+  name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary
- Every other domain's `namespace.yaml` uses `metadata.name: _`, relying on Kustomize's namespace transformer to rewrite it to match the sibling `kustomization.yaml`'s `namespace:` field.
- `apps/development/namespace.yaml` hardcoded `name: development` instead. Functionally harmless today (the value matches), but it's an outlier that could confuse copy-pasting this file as a template for a new domain, and is an easy-to-miss second place to update if the namespace is ever renamed.
- Switches it to the `_` placeholder used everywhere else.

## Test plan
- [ ] `kustomize build apps/development` still renders `Namespace: development`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQr1Tn2MSvRei8pAQnMPfc)_