### PR TITLE
chore(renovate): prune package rules for apps no longer deployed

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -2,13 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "description": "Group Penpot components",
-      "groupName": "penpot",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["/penpotapp/"],
-      "minimumGroupSize": 4
-    },
-    {
       "description": "Group SparkyFitness components",
       "groupName": "sparkyfitness",
       "matchDatasources": ["docker"],

--- a/.renovate/versions.json5
+++ b/.renovate/versions.json5
@@ -13,18 +13,8 @@
     },
     {
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["onerahmet/openai-whisper-asr-webservice"],
-      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-gpu$"
-    },
-    {
-      "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/immich-app/immich-machine-learning"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-cuda$"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/papra-hq/papra"],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-rootless$"
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
## Summary
- `.renovate/groups.json5` had a `penpot` group rule and `.renovate/versions.json5` had versioning rules for `onerahmet/openai-whisper-asr-webservice` and `ghcr.io/papra-hq/papra`, none of which match any package currently deployed under `apps/` (verified via grep — no penpot/whisper/papra app exists in the repo).
- These are presumably leftovers from apps that were removed from the cluster. Harmless (Renovate just never matches them) but pruned for clarity so the config reflects what's actually deployed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQr1Tn2MSvRei8pAQnMPfc)_