### PR TITLE
chore(taskfiles): wire up delete-stuck-ns.sh as a task

### DIFF
--- a/.taskfiles/cluster.yaml
+++ b/.taskfiles/cluster.yaml
@@ -1,0 +1,7 @@
+---
+version: "3"
+
+tasks:
+  delete-stuck-ns:
+    desc: Force-delete namespaces stuck in a Terminating state by clearing their finalizers.
+    cmd: bash {{.ROOT_DIR}}/.scripts/delete-stuck-ns.sh

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,6 +2,7 @@
 version: "3"
 
 includes:
+  cluster: .taskfiles/cluster.yaml
   lint: .taskfiles/lint.yaml
   sops: .taskfiles/sops.yaml
   volsync: .taskfiles/volsync.yaml


### PR DESCRIPTION
## Summary
- Every script in `.scripts/` except `delete-stuck-ns.sh` has a corresponding Taskfile entry, making it undiscoverable via `task -l`.
- Adds a new `.taskfiles/cluster.yaml` with a `cluster:delete-stuck-ns` task wrapping it, and includes it from the root `Taskfile.yaml`.

## Test plan
- [ ] `task -l` lists `cluster:delete-stuck-ns`
- [ ] `task cluster:delete-stuck-ns` runs the script unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQr1Tn2MSvRei8pAQnMPfc)_