### PR TITLE
docs(readme): link to AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 GitOps repository for my Kubernetes Cluster.
 
+See [AGENTS.md](AGENTS.md) for repository structure, tooling, and operational notes.
+
 ## ⭐ Stargazers
 
 <div align="center">


### PR DESCRIPTION
## Summary
- `README.md` had no pointer to `AGENTS.md`, which carries the actual repository structure, tooling, and operational documentation, so a human landing on the repo root had no way to discover it.
- Adds a one-line link.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQr1Tn2MSvRei8pAQnMPfc)_