### PR TITLE
docs(blackbox-exporter): note chart only supports kind=Deployment

### DIFF
--- a/apps/monitoring-system/blackbox-exporter/app/helm-release.yaml
+++ b/apps/monitoring-system/blackbox-exporter/app/helm-release.yaml
@@ -11,6 +11,9 @@ spec:
     name: blackbox-exporter
 
   values:
+    # NOTE: the chart's templates only have a rendering branch for
+    # kind=Deployment. Any other value (e.g. StatefulSet) silently renders no
+    # workload at all, with Helm still reporting success.
     kind: Deployment
     fullnameOverride: blackbox-exporter
 


### PR DESCRIPTION
## Summary
- Investigated the `BlackboxProbeFailed`/`TargetDown` alerts that started after `blackbox-exporter` was brought back under Flux management.
- Root cause was already fixed directly on `main` by two commits earlier today: `e8df4fb` (wire the directory into `apps/monitoring-system/kustomization.yaml`, since it was never referenced) and `87324ac` (the `prometheus-blackbox-exporter` chart only has a template branch for `kind: Deployment` — a `StatefulSet` value silently rendered zero workload objects while Helm still reported success, which took the NFS probe target down).
- This PR just adds a comment on the `kind: Deployment` value explaining the constraint, so it isn't reintroduced by accident.

## Test plan
- [x] Diff reviewed — comment-only change, no behavioral/manifest change.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011y752sjUYQGVZmmxMqWTyZ)_