### PR TITLE
feat(hermes): connect directly to Qwen cloud instead of via litellm

### DIFF
--- a/apps/ai/hermes/app/external-secret.yaml
+++ b/apps/ai/hermes/app/external-secret.yaml
@@ -27,10 +27,10 @@ spec:
               - key: env
 
   data:
-    - secretKey: LITELLM_API_KEY
+    - secretKey: QWEN_KEY
       remoteRef:
-        key: Hermes - LiteLLM
-        property: password
+        key: LiteLLM
+        property: QWEN_KEY
 
     - secretKey: DISCORD_BOT_TOKEN
       remoteRef:

--- a/apps/ai/hermes/app/files/config.yaml
+++ b/apps/ai/hermes/app/files/config.yaml
@@ -1,10 +1,10 @@
 model:
-  default: hermes
+  default: qwen3.7-plus
 
 providers:
-  litellm:
-    base_url: http://litellm:4000/v1
-    api_key: "{{ .LITELLM_API_KEY }}"
+  qwen:
+    base_url: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+    api_key: "{{ .QWEN_KEY }}"
 
 gateway:
   api_server:
@@ -56,8 +56,8 @@ mcp_servers:
   #   command: "npx"
   #   args: ["-y", "mcp-openai-image-generator", "--models", "wan2.7", "wan2.7-pro"]
   #   env:
-  #     OPENAI_API_KEY: "{{ .LITELLM_API_KEY }}"
-  #     OPENAI_BASE_URL: "http://litellm:4000/v1"
+  #     OPENAI_API_KEY: "{{ .QWEN_KEY }}"
+  #     OPENAI_BASE_URL: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
 
 toolsets:
   - hermes-cli


### PR DESCRIPTION
Hermes previously proxied all chat requests through litellm, which for
the "hermes" alias just forwarded to Qwen's Aliyun MaaS endpoint using
qwen3.7-plus. Point Hermes at that endpoint directly and drop the
litellm hop, reusing the same QWEN_KEY already stored for litellm.