### PR TITLE
feat(hermes): connect directly to Qwen cloud instead of via litellm

### DIFF
--- a/apps/ai/hermes/app/external-secret.yaml
+++ b/apps/ai/hermes/app/external-secret.yaml
@@ -27,10 +27,10 @@ spec:
               - key: env
 
   data:
-    - secretKey: LITELLM_API_KEY
+    - secretKey: QWEN_KEY
       remoteRef:
-        key: Hermes - LiteLLM
-        property: password
+        key: LiteLLM
+        property: QWEN_KEY
 
     - secretKey: DISCORD_BOT_TOKEN
       remoteRef:

--- a/apps/ai/hermes/app/files/config.yaml
+++ b/apps/ai/hermes/app/files/config.yaml
@@ -1,10 +1,10 @@
 model:
-  default: hermes
+  default: qwen3.7-plus
 
 providers:
-  litellm:
-    base_url: http://litellm:4000/v1
-    api_key: "{{ .LITELLM_API_KEY }}"
+  qwen:
+    base_url: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+    api_key: "{{ .QWEN_KEY }}"
 
 gateway:
   api_server:
@@ -56,8 +56,8 @@ mcp_servers:
   #   command: "npx"
   #   args: ["-y", "mcp-openai-image-generator", "--models", "wan2.7", "wan2.7-pro"]
   #   env:
-  #     OPENAI_API_KEY: "{{ .LITELLM_API_KEY }}"
-  #     OPENAI_BASE_URL: "http://litellm:4000/v1"
+  #     OPENAI_API_KEY: "{{ .QWEN_KEY }}"
+  #     OPENAI_BASE_URL: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
 
 toolsets:
   - hermes-cli

--- a/apps/ai/hermes/app/helm-release.yaml
+++ b/apps/ai/hermes/app/helm-release.yaml
@@ -30,8 +30,8 @@ spec:
 
           init:
             image:
-              repository: docker.io/mikefarah/yq
-              tag: "4"
+              repository: docker.io/library/busybox
+              tag: latest
             securityContext:
               runAsUser: 10000
               runAsGroup: 10000
@@ -40,13 +40,11 @@ spec:
               - -c
               - |
                 set -euo pipefail
-                if [ -f /opt/data/config.yaml ]; then
-                  yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' \
-                    /opt/data/config.yaml /tmp/config.yaml > /tmp/merged.yaml
-                  mv /tmp/merged.yaml /opt/data/config.yaml
-                else
-                  cp /tmp/config.yaml /opt/data/config.yaml
-                fi
+                # Always overwrite: config.yaml is fully managed by the
+                # Secret template. A merge previously left stale, renamed,
+                # or removed keys (e.g. old providers) permanently stuck
+                # on the PVC across redeploys.
+                cp /tmp/config.yaml /opt/data/config.yaml
                 cp /tmp/.env /opt/data/.env
 
         containers:


### PR DESCRIPTION
## Summary
- Hermes now talks directly to Qwen's Aliyun MaaS endpoint instead of proxying chat requests through litellm. `providers.litellm` → `providers.qwen` (pointed at `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`), and `model.default` changed from litellm's `hermes` alias to the real model id `qwen3.7-plus`.
- The Hermes ExternalSecret now pulls `QWEN_KEY` from the same 1Password `LiteLLM` item (instead of `LITELLM_API_KEY`), so no new secret is needed.
- Fixed the init container that seeds `config.yaml` onto the PVC: it previously deep-merged the persisted config with the freshly rendered template, which meant renamed/removed keys (like the old `providers.litellm` block) stuck around forever across redeploys instead of being replaced. It now just overwrites `config.yaml` outright, since the file is fully owned by the Secret template. Also dropped the now-unneeded `mikefarah/yq` init image in favor of the `busybox` image already used by the `fix-run` init container.

## Test plan
- [ ] `flux reconcile` and confirm Hermes redeploys with the new `config.yaml` (single `qwen` provider, no stale `litellm` entry)
- [ ] Confirm Hermes chat requests hit Qwen's Aliyun endpoint directly (not litellm)
- [ ] Confirm `hermano` (which talks to Hermes's API) still works unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEWtR7x9MhUado186wfV3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEWtR7x9MhUado186wfV3r)_