### PR TITLE
feat(renovate): group Talos version updates into a single PR

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -53,6 +53,11 @@
       "groupName": "cnpg-postgres",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["/cloudnative-pg/postgresql/"]
+    },
+    {
+      "description": "Group Talos version updates (talosctl CLI in mise + container image, siderolabs/installer) so they land as a single commit instead of separate PRs per source",
+      "groupName": "talos",
+      "matchPackageNames": ["ghcr.io/siderolabs/installer", "/talosctl$/"]
     }
   ]
 }

--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -57,7 +57,8 @@
     {
       "description": "Group Talos version updates (talosctl CLI in mise + container image, siderolabs/installer) so they land as a single commit instead of separate PRs per source",
       "groupName": "talos",
-      "matchPackageNames": ["ghcr.io/siderolabs/installer", "/talosctl$/"]
+      "matchPackageNames": ["ghcr.io/siderolabs/installer", "/talosctl$/"],
+      "minimumGroupSize": 2
     }
   ]
 }


### PR DESCRIPTION
talosctl (mise) and the siderolabs/installer container image both
track the Talos release version and previously landed as separate
renovate PRs (e.g. the 1.13.8 -> 1.13.9 bump), requiring multiple
merges for what is really one version change.