### PR TITLE
feat(monitoring-system): alert on stopped TrueNAS containers

### DIFF
--- a/apps/monitoring-system/kube-prometheus-stack/app/prometheus-rules/truenas.yaml
+++ b/apps/monitoring-system/kube-prometheus-stack/app/prometheus-rules/truenas.yaml
@@ -19,3 +19,15 @@ spec:
           annotations:
             summary: "NAS {{ $labels.instance }} is unreachable"
             description: "No metrics received from {{ $labels.instance }} for more than 2 minutes."
+
+        # -----------------------------------------------------------------------
+        # Containers
+        # -----------------------------------------------------------------------
+        - alert: NASContainerDown
+          expr: time() - container_last_seen{job="cadvisor", name!=""} > 90
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "NAS container {{ $labels.name }} is down"
+            description: "cadvisor hasn't seen container {{ $labels.name }} ({{ $labels.image }}) for more than 2 minutes — it may have stopped or failed to restart."


### PR DESCRIPTION
## Summary
- Adds `NASContainerDown`, a PrometheusRule alert firing when cadvisor's `container_last_seen` for any named container on the NAS goes stale for >2m.
- The existing `NASDown` alert only covers the whole host being unreachable (`node-exporter` up/down); it has no visibility into a single container stopping while the host stays up.

## Context
Traced during investigation of failing CNPG seed job alerts: the `traefik` app on TrueNAS silently stopped for ~28 minutes after a routine image bump failed (`no matching manifest for linux/amd64` — a transient Docker Hub registry propagation issue). Since Traefik fronts `*.nas.svc.h.mirceanton.com`, this broke Garage S3 access for every CNPG cluster's WAL archiving cluster-wide, only surfacing indirectly via CNPG job failures. cadvisor was already scraping `container_last_seen` for `traefik` the entire time and clearly showed it stall — there was just no alert rule watching it.

## Test plan
- [x] Validated `time() - container_last_seen{job="cadvisor", name!=""} > 90` against live Prometheus — currently returns no results (no false positives).
- [x] Confirmed against historical data that the same expression would have caught the actual Traefik outage window (`container_last_seen` for the old traefik container stalled at `2026-08-19T18:19:55Z`).
- [ ] Confirm PrometheusRule reconciles and rule appears in Prometheus after merge.