### PR TITLE
chore(renovate): track OCI-mounted binary versions in renovate job

### DIFF
--- a/apps/github-actions/renovate/jobs/renovate-job.yaml
+++ b/apps/github-actions/renovate/jobs/renovate-job.yaml
@@ -65,14 +65,17 @@ spec:
         claimName: renovate-cache
     - name: mise-bin
       image:
+        # renovate: depName=ghcr.io/jdx/mise datasource=docker
         reference: ghcr.io/jdx/mise:2026.8.3
         pullPolicy: IfNotPresent
     - name: helm-docs-bin
       image:
+        # renovate: depName=jnorwood/helm-docs datasource=docker
         reference: docker.io/jnorwood/helm-docs:v1.14.2
         pullPolicy: IfNotPresent
     - name: helm-schema-bin
       image:
+        # renovate: depName=ghcr.io/dadav/helm-schema datasource=docker
         reference: ghcr.io/dadav/helm-schema:v0.23.4
         pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Add `# renovate: depName=... datasource=docker` comments above the `reference:` fields for the three OCI-mounted binaries (`mise`, `helm-docs`, `helm-schema`) in the self-hosted Renovate job, so Renovate tracks and bumps them like everything else instead of them silently drifting.
- Follows the same comment-override pattern already used for the CNPG `image.reference` fields elsewhere in the repo (e.g. `apps/productivity/affine/app/patches/cnpg.yaml`).

Context: the `mise` pin (`2026.8.3`) had drifted behind the `mise` version CI installs fresh via `jdx/mise-action`. Renovate's `postUpgradeTasks` runs `mise lock` using this pinned binary, which for `aqua`-backend tools with GitHub attestations wrote lockfile entries with only `provenance`, no `checksum`/`url`. A newer `mise install --locked` in CI (mise 2026.8.9) rejects provenance-only entries outright, which broke several downstream Go-repo Renovate PRs across the org. Keeping this binary tracked by Renovate should prevent that skew going forward.

## Test plan
- [ ] Confirm Renovate picks up the three deps on its next run (dependency dashboard / new PRs against `ghcr.io/jdx/mise`, `jnorwood/helm-docs`, `ghcr.io/dadav/helm-schema`)