### PR TITLE
fix(streamarr): alert on individual media items instead of an aggregate

### DIFF
--- a/apps/downloads/streamarr/app/prometheus-rule.yaml
+++ b/apps/downloads/streamarr/app/prometheus-rule.yaml
@@ -9,14 +9,15 @@ spec:
     - name: streamarr.rules
       rules:
         - alert: StreamarrMediaNeedsAttention
-          expr: sum(streamarr_media_needs_attention_total) > 0
+          expr: streamarr_media_item_needs_attention == 1
           for: 5m
           labels:
             severity: warning
           annotations:
-            summary: "Streamarr media needs attention"
+            summary: "{{ $labels.title }} needs attention"
             description: >-
-              {{ $value }} media items are flagged as needing attention
+              {{ $labels.type }} "{{ $labels.title }}"{{ if $labels.season }} S{{ $labels.season }}E{{ $labels.episode }}{{ end }}
+              (streamarr id {{ $labels.id }}) is flagged as needing attention
               (missing language or subtitle preferences).
 
         - alert: StreamarrJobsStuck


### PR DESCRIPTION
## Summary
- `StreamarrMediaNeedsAttention` used to fire on `sum(streamarr_media_needs_attention_total) > 0`, so every flagged media item collapsed into a single Alertmanager fingerprint (label set was just `severity`). Once Hermano/Hermes marked that alert "completed", a *different* item tripping the same rule read as a recurrence of an already-fixed alert and never got delegated.
- Switches the rule to `streamarr_media_item_needs_attention == 1`, a new per-item metric (labeled `id`/`type`/`title`/`season`/`episode`) added in [mirceanton/streamarr#feat/media-item-attention-metric](https://github.com/mirceanton/streamarr/tree/feat/media-item-attention-metric) — PR not yet opened there. Each item now gets its own label set and therefore its own Alertmanager fingerprint, so Hermano tracks and delegates every item independently.

## Dependency
This rule references a metric name that doesn't exist in the currently-deployed streamarr image yet — it needs the linked streamarr change released and the image tag bumped before `StreamarrMediaNeedsAttention` will fire again (it'll just stay pending/inactive until then, no behavior regression).

## Test plan
- [ ] Release streamarr with the new `streamarr_media_item_needs_attention` metric and bump the image tag here
- [ ] Confirm the metric appears in Prometheus with distinct `id` labels per flagged item
- [ ] Confirm two different media items needing attention produce two independent alerts/fingerprints in Alertmanager, and that Hermano delegates both