### PR TITLE
feat(comfyui): deploy ComfyUI for AI video generation

### DIFF
--- a/apps/ai/comfyui/app.ks.yaml
+++ b/apps/ai/comfyui/app.ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app comfyui
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: ai
+
+  path: ./apps/ai/comfyui/app
+  components:
+    - ../../../../components/volsync/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: 1password-connect
+      namespace: security-system
+    - name: openebs
+      namespace: storage-system
+    - name: volsync
+      namespace: storage-system

--- a/apps/ai/comfyui/app/external-secret.yaml
+++ b/apps/ai/comfyui/app/external-secret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name comfyui-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    # Same DashScope/QwenCloud token-plan key litellm uses (apps/ai/litellm/app/external-secret.yaml) -
+    # calling DashScope directly here, not through litellm.
+    - secretKey: QWEN_KEY
+      remoteRef:
+        key: LiteLLM
+        property: QWEN_KEY

--- a/apps/ai/comfyui/app/helm-release.yaml
+++ b/apps/ai/comfyui/app/helm-release.yaml
@@ -1,0 +1,145 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: comfyui
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: comfyui
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      comfyui:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              # ai-dock ships CUDA-ready ComfyUI + ComfyUI-Manager preinstalled.
+              # TODO: verify/bump this tag against https://github.com/ai-dock/comfyui
+              # releases - renovate will track it from here on.
+              repository: ghcr.io/ai-dock/comfyui
+              tag: v2-cuda-12.1.1-base-22.04-v0.2.7
+
+            env:
+              # Used by a ComfyUI custom node (install via ComfyUI-Manager) that
+              # calls DashScope directly - going straight to Alibaba rather than
+              # through litellm, whose OpenAI-compatible routing doesn't cover
+              # DashScope's async video-generation task API. Same host your
+              # QwenCloud token-plan subscription uses for litellm's qwen/wan/
+              # happyhorse models (apps/ai/litellm/app/files/config.yaml), minus
+              # the /compatible-mode/v1 suffix that's specific to litellm's
+              # OpenAI-style chat/embedding calls.
+              # TODO: confirm the exact path/task-polling shape the DashScope
+              # node you install expects (native video-synthesis API is
+              # async: submit task -> poll -> fetch result URL).
+              DASHSCOPE_BASE_URL: https://token-plan.ap-southeast-1.maas.aliyuncs.com
+              DASHSCOPE_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: comfyui-secret
+                    key: QWEN_KEY
+
+            resources:
+              requests:
+                cpu: 500m
+                memory: 4Gi
+                nvidia.com/gpu: "1"
+              limits:
+                memory: 24Gi
+                nvidia.com/gpu: "1"
+
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: { port: 8188 }
+                  initialDelaySeconds: 180
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 10
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: { port: 8188 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 40
+
+            # NOTE: ai-dock images commonly expect to run as root for their
+            # provisioning/supervisord bootstrap - left unrestricted here.
+            # Tighten once you confirm the image works as a non-root user.
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      enableServiceLinks: false
+      runtimeClassName: nvidia
+      terminationGracePeriodSeconds: 30
+
+    service:
+      app:
+        controller: comfyui
+        ports:
+          http:
+            port: 8188
+
+    route:
+      main:
+        hostnames: ["comfyui.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      # Not backed up - model weights & installed nodes are re-fetchable.
+      models:
+        existingClaim: comfyui-cache
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /workspace/ComfyUI/models
+                subPath: models
+      custom-nodes:
+        existingClaim: comfyui-cache
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /workspace/ComfyUI/custom_nodes
+                subPath: custom_nodes
+
+      # Backed up via volsync - your actual creative assets: uploaded icons,
+      # generated clips, and saved workflows.
+      input:
+        existingClaim: ${APP}
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /workspace/ComfyUI/input
+                subPath: input
+      output:
+        existingClaim: ${APP}
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /workspace/ComfyUI/output
+                subPath: output
+      user:
+        existingClaim: ${APP}
+        advancedMounts:
+          comfyui:
+            app:
+              - path: /workspace/ComfyUI/user
+                subPath: user

--- a/apps/ai/comfyui/app/kustomization.yaml
+++ b/apps/ai/comfyui/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./external-secret.yaml
+  - ./models-pvc.yaml
+  - ./helm-release.yaml

--- a/apps/ai/comfyui/app/models-pvc.yaml
+++ b/apps/ai/comfyui/app/models-pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 150Gi
+  storageClassName: openebs-zfs-cache

--- a/apps/ai/comfyui/app/oci-repository.yaml
+++ b/apps/ai/comfyui/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: comfyui
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.1.0
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/ai/comfyui/kustomization.yaml
+++ b/apps/ai/comfyui/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: flux-system
+
+resources:
+  - ./app.ks.yaml

--- a/apps/ai/kustomization.yaml
+++ b/apps/ai/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./namespace.yaml
   - ./grafana-folder.yaml
 
+  - ./comfyui
   - ./github-mcp
   - ./hermano
   - ./hermes


### PR DESCRIPTION
## Summary
- Deploy ComfyUI (`ghcr.io/ai-dock/comfyui`) in the `ai` namespace, GPU-scheduled on the RTX 4070 node for local model inference (e.g. Wan1.3B for cheap iteration/drafts).
- Wire it directly to DashScope using the existing QwenCloud token-plan key (reused from the `LiteLLM` 1Password item's `QWEN_KEY`), to call the WAN / HappyHorse video-generation models on the same subscription litellm already proxies for chat/embeddings.
- Intended use: generate 5-30s animations for YouTube videos from uploaded PNG/SVG icon assets + a script/description. `happyhorse-1.1-r2v` (reference-to-video) is the best fit for icon-conditioned generation.
- 150Gi cache PVC (`openebs-zfs-cache`, not backed up) for model weights + custom nodes; a separate volsync-backed PVC for `input/`, `output/`, `user/` (actual creative assets worth keeping).

## Notes for reviewer
- Went direct to DashScope rather than through litellm, since litellm's OpenAI-compatible routing doesn't cover DashScope's async video-generation task API (submit task → poll → fetch result).
- No off-the-shelf ComfyUI node calls DashScope's video API yet — after first boot you'll need to install/write a custom node via the preinstalled ComfyUI-Manager, pointed at `DASHSCOPE_BASE_URL`/`DASHSCOPE_API_KEY`. Left a `TODO` comment on the base URL since I stripped litellm's `/compatible-mode/v1` suffix but haven't confirmed the exact path the eventual node expects.
- `ghcr.io/ai-dock/comfyui` tag is a real tag pulled from kubesearch.dev (other home-ops users run it); renovate should take over version bumps from here.

## Test plan
- [x] `kubectl kustomize apps/ai/comfyui/app` and `apps/ai` build cleanly
- [x] `prettier --check` passes
- [ ] Flux reconciles the Kustomization/HelmRelease without errors
- [ ] Pod schedules onto the GPU node and comes up healthy
- [ ] DashScope call succeeds once a video-gen custom node is installed and pointed at `DASHSCOPE_BASE_URL`/`DASHSCOPE_API_KEY`