### PR TITLE
fix(comfyui): don't drop capabilities, ai-dock needs setuid/setgid

### DIFF
--- a/apps/ai/comfyui/app/helm-release.yaml
+++ b/apps/ai/comfyui/app/helm-release.yaml
@@ -77,12 +77,14 @@ spec:
                   timeoutSeconds: 5
                   failureThreshold: 40
 
-            # NOTE: ai-dock images commonly expect to run as root for their
-            # provisioning/supervisord bootstrap - left unrestricted here.
-            # Tighten once you confirm the image works as a non-root user.
+            # Confirmed needed: ai-dock's supervisord starts as root and
+            # setuid/setgid's each managed process (comfyui, jupyter,
+            # syncthing, ...) down to uid 1000 individually. Dropping
+            # capabilities breaks that - every child process fails with
+            # "couldn't setuid to 1000: Could not set groups of effective
+            # user" and the container crash-loops.
             securityContext:
               allowPrivilegeEscalation: false
-              capabilities: { drop: ["ALL"] }
 
     defaultPodOptions:
       enableServiceLinks: false


### PR DESCRIPTION
## Summary
The `comfyui` pod deployed in #936 was stuck crash-looping after the disk-pressure scheduling issue cleared. Logs showed every supervisord-managed process failing:

```
supervisor: couldn't setuid to 1000: Could not set groups of effective user
2026-08-23 22:18:19,795 INFO exited: comfyui (exit status 127; not expected)
2026-08-23 22:18:19,797 INFO gave up: comfyui entered FATAL state, too many start retries too quickly
```

`ghcr.io/ai-dock/comfyui`'s entrypoint runs supervisord as root and drops privileges to uid 1000 per-process. `capabilities: { drop: ["ALL"] }` in the original helm-release strips `CAP_SETUID`/`CAP_SETGID`, so that drop fails and nothing starts.

## Fix
Removed the capability drop, keeping `allowPrivilegeEscalation: false`. This was called out as an unverified TODO in the original PR and is now confirmed via the crash-loop.

## Test plan
- [x] `kubectl kustomize apps/ai/comfyui/app` builds cleanly
- [x] `prettier --check` passes
- [ ] Pod reaches `Running`/`Ready` after this merges and Flux reconciles