### PR TITLE
fix(comfyui): switch to yanwk/comfyui-boot, ai-dock redirects to localhost

### DIFF
--- a/apps/ai/comfyui/app/helm-release.yaml
+++ b/apps/ai/comfyui/app/helm-release.yaml
@@ -22,13 +22,23 @@ spec:
         containers:
           app:
             image:
-              # ai-dock ships CUDA-ready ComfyUI + ComfyUI-Manager preinstalled.
-              # TODO: verify/bump this tag against https://github.com/ai-dock/comfyui
-              # releases - renovate will track it from here on.
-              repository: ghcr.io/ai-dock/comfyui
-              tag: v2-cuda-12.1.1-base-22.04-v0.2.7
+              # yanwk/comfyui-boot: just ComfyUI + ComfyUI-Manager, listens on
+              # whatever CLI_ARGS says. cu130 is the officially recommended
+              # CUDA version for Ada Lovelace (RTX 4070) - see
+              # https://github.com/YanWenKun/ComfyUI-Docker#cuda-compatibility
+              # Switched from ghcr.io/ai-dock/comfyui, whose bundled Caddy +
+              # cloud-rental service portal (designed for RunPod/Vast.ai proxy
+              # tunnels) redirected browser requests to "localhost" instead of
+              # serving the app behind our own ingress hostname.
+              repository: yanwk/comfyui-boot
+              tag: cu130-slim-v2@sha256:32efcc9d6d5ea9d6b73794cd658c9c09524ba932f7aa105580003c9b69d30bbc
 
             env:
+              # ComfyUI defaults to listening on 127.0.0.1 - has to be told
+              # explicitly to listen on all interfaces to be reachable at all
+              # from the Service/route.
+              CLI_ARGS: "--listen 0.0.0.0 --port 8188"
+
               # Used by a ComfyUI custom node (install via ComfyUI-Manager) that
               # calls DashScope directly - going straight to Alibaba rather than
               # through litellm, whose OpenAI-compatible routing doesn't cover
@@ -62,7 +72,7 @@ spec:
                 custom: true
                 spec:
                   tcpSocket: { port: 8188 }
-                  initialDelaySeconds: 180
+                  initialDelaySeconds: 60
                   periodSeconds: 15
                   timeoutSeconds: 5
                   failureThreshold: 10
@@ -72,17 +82,11 @@ spec:
                 custom: true
                 spec:
                   tcpSocket: { port: 8188 }
-                  initialDelaySeconds: 30
+                  initialDelaySeconds: 15
                   periodSeconds: 15
                   timeoutSeconds: 5
                   failureThreshold: 40
 
-            # Confirmed needed: ai-dock's supervisord starts as root and
-            # setuid/setgid's each managed process (comfyui, jupyter,
-            # syncthing, ...) down to uid 1000 individually. Dropping
-            # capabilities breaks that - every child process fails with
-            # "couldn't setuid to 1000: Could not set groups of effective
-            # user" and the container crash-loops.
             securityContext:
               allowPrivilegeEscalation: false
 
@@ -112,14 +116,14 @@ spec:
         advancedMounts:
           comfyui:
             app:
-              - path: /workspace/ComfyUI/models
+              - path: /root/ComfyUI/models
                 subPath: models
       custom-nodes:
         existingClaim: comfyui-cache
         advancedMounts:
           comfyui:
             app:
-              - path: /workspace/ComfyUI/custom_nodes
+              - path: /root/ComfyUI/custom_nodes
                 subPath: custom_nodes
 
       # Backed up via volsync - your actual creative assets: uploaded icons,
@@ -129,19 +133,19 @@ spec:
         advancedMounts:
           comfyui:
             app:
-              - path: /workspace/ComfyUI/input
+              - path: /root/ComfyUI/input
                 subPath: input
       output:
         existingClaim: ${APP}
         advancedMounts:
           comfyui:
             app:
-              - path: /workspace/ComfyUI/output
+              - path: /root/ComfyUI/output
                 subPath: output
       user:
         existingClaim: ${APP}
         advancedMounts:
           comfyui:
             app:
-              - path: /workspace/ComfyUI/user
+              - path: /root/ComfyUI/user
                 subPath: user


### PR DESCRIPTION
## Problem
Navigating to `comfyui.home.mirceanton.com` redirects to `localhost` instead of loading the app. `ghcr.io/ai-dock/comfyui` bundles a Caddy reverse proxy + a service-portal UI (plus Cloudflare quick tunnels, seen auto-starting in the pod logs) built for cloud-GPU-rental platforms like RunPod/Vast.ai, which proxy access through their own tunnel rather than a normal custom-domain ingress. Its redirect logic assumes that access model and doesn't work behind our Envoy Gateway route.

## Fix
Switched to `yanwk/comfyui-boot` - confirmed via three other public home-ops repos actually running it in production (two on NVIDIA/CPU, one on AMD ROCm). It's just ComfyUI + ComfyUI-Manager listening directly on whatever port `CLI_ARGS` specifies, no portal/proxy layer.

- `cu130-slim-v2`: CUDA 13.0 is the version [officially recommended](https://github.com/YanWenKun/ComfyUI-Docker#cuda-compatibility) for Ada Lovelace (RTX 4070) by the image's own docs; `slim` starts with just ComfyUI + Manager (easier to add nodes incrementally vs. the `megapak` all-in-one variant).
- `CLI_ARGS: "--listen 0.0.0.0 --port 8188"` - ComfyUI defaults to `127.0.0.1`, has to be told explicitly to bind all interfaces.
- Persistence mount paths updated from ai-dock's `/workspace/ComfyUI` to this image's `/root/ComfyUI` layout.
- Dropped the now-irrelevant `privileged`/capability workarounds - this image doesn't run a multi-service supervisord needing setuid, and NVIDIA's own quick-start docs don't require `privileged: true` (unlike the AMD/ROCm example repos, which do).

## Test plan
- [x] `kubectl kustomize apps/ai/comfyui/app` builds cleanly
- [x] `prettier --check` passes
- [ ] Pod reaches `Running`/`Ready` after merge + reconcile
- [ ] `https://comfyui.home.mirceanton.com` loads the actual ComfyUI UI, not a localhost redirect