### PR TITLE
fix(container): update ghcr.io/mirceanton/model-hub ( v0.8.0 → v0.9.0 )

### DIFF
--- a/apps/maker/modelhub/app/helm-release.yaml
+++ b/apps/maker/modelhub/app/helm-release.yaml
@@ -59,12 +59,6 @@ spec:
 
               # OIDC / Keycloak SSO
               OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
-              # Bootstrap escape hatch (v0.9.0+): the OIDC group->role mapping
-              # is otherwise DB-only, configured via /admin — which itself
-              # requires admin role, so a fresh instance has no way to reach
-              # it. Enforced fresh on every boot ("always wins"), so this
-              # group can never get locked out of admin even via a stray DB
-              # edit. See CLAUDE.md's Auth/Roles section in model-hub.
               OIDC_ADMIN_GROUPS: modelhub-admins
               OIDC_CLIENT_ID:
                 valueFrom:

--- a/apps/maker/modelhub/app/helm-release.yaml
+++ b/apps/maker/modelhub/app/helm-release.yaml
@@ -33,7 +33,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/model-hub
-              tag: v0.8.0
+              tag: v0.9.0
 
             env:
               PORT: &port 4000
@@ -59,6 +59,13 @@ spec:
 
               # OIDC / Keycloak SSO
               OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+              # Bootstrap escape hatch (v0.9.0+): the OIDC group->role mapping
+              # is otherwise DB-only, configured via /admin — which itself
+              # requires admin role, so a fresh instance has no way to reach
+              # it. Enforced fresh on every boot ("always wins"), so this
+              # group can never get locked out of admin even via a stray DB
+              # edit. See CLAUDE.md's Auth/Roles section in model-hub.
+              OIDC_ADMIN_GROUPS: modelhub-admins
               OIDC_CLIENT_ID:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Bumps model-hub to v0.9.0 and sets `OIDC_ADMIN_GROUPS=modelhub-admins`.

That new env var is a bootstrap escape hatch for the RBAC feature that shipped in v0.8.0: the OIDC group→role mapping is DB-only, configured via `/admin` — which itself requires admin role, so without this a fresh deploy has no way to reach the page that would let you configure it. `OIDC_ADMIN_GROUPS` is enforced fresh on every boot ("the env var always wins"), so the `modelhub-admins` Keycloak group can never end up locked out of admin.