### PR TITLE
feat(youtube): deploy youtube-exporter

### DIFF
--- a/apps/youtube/grafana-folder.yaml
+++ b/apps/youtube/grafana-folder.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/grafana.integreatly.org/grafanafolder_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: youtube
+spec:
+  title: YouTube
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana

--- a/apps/youtube/kustomization.yaml
+++ b/apps/youtube/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./namespace.yaml
   - ./davinci
   - ./teleprompter
+  - ./youtube-exporter

--- a/apps/youtube/kustomization.yaml
+++ b/apps/youtube/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: youtube
 
 resources:
   - ./namespace.yaml
+  - ./grafana-folder.yaml
   - ./davinci
   - ./teleprompter
   - ./youtube-exporter

--- a/apps/youtube/youtube-exporter/app.ks.yaml
+++ b/apps/youtube/youtube-exporter/app.ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: youtube-exporter
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  targetNamespace: youtube
+
+  path: ./apps/youtube/youtube-exporter/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute: {}
+
+  dependsOn:
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: 1password-connect
+      namespace: security-system

--- a/apps/youtube/youtube-exporter/app/dashboard.json
+++ b/apps/youtube/youtube-exporter/app/dashboard.json
@@ -377,7 +377,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
-          "expr": "youtube_video_view_count",
+          "expr": "label_replace(sum by (video_id, title) (youtube_video_view_count), \"__name__\", \"views\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -385,7 +385,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
-          "expr": "youtube_video_like_count",
+          "expr": "label_replace(sum by (video_id, title) (youtube_video_like_count), \"__name__\", \"likes\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -393,7 +393,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
-          "expr": "youtube_video_comment_count",
+          "expr": "label_replace(sum by (video_id, title) (youtube_video_comment_count), \"__name__\", \"comments\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -402,6 +402,16 @@
       ],
       "title": "Per-Video Stats",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "exclude": { "pattern": "__name__" }
+          }
+        },
         {
           "id": "merge",
           "options": {}
@@ -415,16 +425,16 @@
             "indexByName": {
               "title": 0,
               "video_id": 1,
-              "Value #Views": 2,
-              "Value #Likes": 3,
-              "Value #Comments": 4
+              "views": 2,
+              "likes": 3,
+              "comments": 4
             },
             "renameByName": {
               "title": "Title",
               "video_id": "Video ID",
-              "Value #Views": "Views",
-              "Value #Likes": "Likes",
-              "Value #Comments": "Comments"
+              "views": "Views",
+              "likes": "Likes",
+              "comments": "Comments"
             }
           }
         }

--- a/apps/youtube/youtube-exporter/app/dashboard.json
+++ b/apps/youtube/youtube-exporter/app/dashboard.json
@@ -1,0 +1,462 @@
+{
+  "version": 2,
+  "uid": "youtube-exporter",
+  "title": "YouTube Exporter",
+  "timezone": "",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "refresh": "5m",
+  "editable": true,
+  "tags": ["youtube", "exporter"],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_channel_subscriber_count",
+          "legendFormat": "Subscribers",
+          "refId": "A"
+        }
+      ],
+      "title": "Subscribers",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_channel_view_count",
+          "legendFormat": "Views",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Views",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_channel_video_count",
+          "legendFormat": "Videos",
+          "refId": "A"
+        }
+      ],
+      "title": "Published Videos",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            {
+              "options": {
+                "0": { "color": "red", "index": 1, "text": "Failing" },
+                "1": { "color": "dark-green", "index": 0, "text": "Healthy" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "dark-green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_exporter_collection_success",
+          "instant": true,
+          "legendFormat": "Status",
+          "refId": "A"
+        }
+      ],
+      "title": "Collector Status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "dark-green", "value": 0 },
+              { "color": "yellow", "value": 900 },
+              { "color": "red", "value": 1800 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 4 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "time() - youtube_exporter_last_collection_timestamp_seconds",
+          "instant": true,
+          "legendFormat": "Age",
+          "refId": "A"
+        }
+      ],
+      "title": "Time Since Last Poll",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "min", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_channel_subscriber_count",
+          "legendFormat": "Subscribers",
+          "refId": "A"
+        }
+      ],
+      "title": "Subscribers Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "min", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_channel_view_count",
+          "legendFormat": "Views",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Views Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": 0 }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Title" },
+            "properties": [{ "id": "custom.width", "value": 400 }]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 16 },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "Views" }]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_video_view_count",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "Views"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_video_like_count",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "Likes"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "youtube_video_comment_count",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "Comments"
+        }
+      ],
+      "title": "Per-Video Stats",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "title": 0,
+              "video_id": 1,
+              "Value #Views": 2,
+              "Value #Likes": 3,
+              "Value #Comments": 4
+            },
+            "renameByName": {
+              "title": "Title",
+              "video_id": "Video ID",
+              "Value #Views": "Views",
+              "Value #Likes": "Likes",
+              "Value #Comments": "Comments"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 0,
+  "links": [],
+  "preload": false,
+  "schemaVersion": 42,
+  "templating": { "list": [] },
+  "timepicker": {}
+}

--- a/apps/youtube/youtube-exporter/app/dashboard.json
+++ b/apps/youtube/youtube-exporter/app/dashboard.json
@@ -12,7 +12,7 @@
   "tags": ["youtube", "exporter"],
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -42,7 +42,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_channel_subscriber_count",
           "legendFormat": "Subscribers",
           "refId": "A"
@@ -52,7 +52,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -82,7 +82,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_channel_view_count",
           "legendFormat": "Views",
           "refId": "A"
@@ -92,7 +92,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -122,7 +122,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_channel_video_count",
           "legendFormat": "Videos",
           "refId": "A"
@@ -132,7 +132,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -173,7 +173,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_exporter_collection_success",
           "instant": true,
           "legendFormat": "Status",
@@ -184,7 +184,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -218,7 +218,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "time() - youtube_exporter_last_collection_timestamp_seconds",
           "instant": true,
           "legendFormat": "Age",
@@ -229,7 +229,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -274,7 +274,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_channel_subscriber_count",
           "legendFormat": "Subscribers",
           "refId": "A"
@@ -284,7 +284,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -329,7 +329,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_channel_view_count",
           "legendFormat": "Views",
           "refId": "A"
@@ -339,7 +339,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -376,7 +376,7 @@
       "pluginVersion": "12.3.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_video_view_count",
           "format": "table",
           "instant": true,
@@ -384,7 +384,7 @@
           "refId": "Views"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_video_like_count",
           "format": "table",
           "instant": true,
@@ -392,7 +392,7 @@
           "refId": "Likes"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "e4315b0f-3597-475f-8726-10fc0ffbdc75" },
           "expr": "youtube_video_comment_count",
           "format": "table",
           "instant": true,

--- a/apps/youtube/youtube-exporter/app/external-secret.yaml
+++ b/apps/youtube/youtube-exporter/app/external-secret.yaml
@@ -16,7 +16,11 @@ spec:
     creationPolicy: Owner
 
   data:
+    - secretKey: CHANNEL_ID
+      remoteRef:
+        key: YouTube Data API
+        property: username
     - secretKey: API_KEY
       remoteRef:
         key: YouTube Data API
-        property: credential
+        property: password

--- a/apps/youtube/youtube-exporter/app/external-secret.yaml
+++ b/apps/youtube/youtube-exporter/app/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name youtube-exporter-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    - secretKey: API_KEY
+      remoteRef:
+        key: YouTube Data API
+        property: credential

--- a/apps/youtube/youtube-exporter/app/grafana-dashboard.yaml
+++ b/apps/youtube/youtube-exporter/app/grafana-dashboard.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: youtube-exporter
+spec:
+  folderRef: youtube
+  configMapRef:
+    name: youtube-exporter-dashboard
+    key: dashboard.json
+
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana

--- a/apps/youtube/youtube-exporter/app/helm-release.yaml
+++ b/apps/youtube/youtube-exporter/app/helm-release.yaml
@@ -37,8 +37,7 @@ spec:
 
             env:
               YOUTUBE_EXPORTER_PORT: &port 8080
-              # TODO: replace with the real channel ID, e.g. UCxxxxxxxxxxxxxxxxxxxxxxxx
-              YOUTUBE_EXPORTER_CHANNEL_ID: "UCXXXXXXXXXXXXXXXXXXXXXX"
+              YOUTUBE_EXPORTER_CHANNEL_ID: "UChoN8zyrrkFGiHdd9iiqLZQ"
               YOUTUBE_EXPORTER_API_KEY:
                 valueFrom:
                   secretKeyRef:

--- a/apps/youtube/youtube-exporter/app/helm-release.yaml
+++ b/apps/youtube/youtube-exporter/app/helm-release.yaml
@@ -37,7 +37,11 @@ spec:
 
             env:
               YOUTUBE_EXPORTER_PORT: &port 8080
-              YOUTUBE_EXPORTER_CHANNEL_ID: "UChoN8zyrrkFGiHdd9iiqLZQ"
+              YOUTUBE_EXPORTER_CHANNEL_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: youtube-exporter-secret
+                    key: CHANNEL_ID
               YOUTUBE_EXPORTER_API_KEY:
                 valueFrom:
                   secretKeyRef:

--- a/apps/youtube/youtube-exporter/app/helm-release.yaml
+++ b/apps/youtube/youtube-exporter/app/helm-release.yaml
@@ -1,0 +1,87 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: youtube-exporter
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: youtube-exporter
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      youtube-exporter:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          main:
+            image:
+              repository: ghcr.io/mirceanton/youtube-exporter
+              tag: v0.1.0
+
+            env:
+              YOUTUBE_EXPORTER_PORT: &port 8080
+              # TODO: replace with the real channel ID, e.g. UCxxxxxxxxxxxxxxxxxxxxxxxx
+              YOUTUBE_EXPORTER_CHANNEL_ID: "UCXXXXXXXXXXXXXXXXXXXXXX"
+              YOUTUBE_EXPORTER_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: youtube-exporter-secret
+                    key: API_KEY
+
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 15
+              readiness: *probe
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      youtube-exporter:
+        controller: youtube-exporter
+        ports:
+          http:
+            port: *port
+
+    serviceMonitor:
+      youtube-exporter:
+        serviceName: youtube-exporter
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 5m
+            scrapeTimeout: 30s

--- a/apps/youtube/youtube-exporter/app/kustomization.yaml
+++ b/apps/youtube/youtube-exporter/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/youtube/youtube-exporter/app/kustomization.yaml
+++ b/apps/youtube/youtube-exporter/app/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
   - ./external-secret.yaml
+  - ./grafana-dashboard.yaml
+
+configMapGenerator:
+  - name: youtube-exporter-dashboard
+    options:
+      disableNameSuffixHash: true
+    files:
+      - dashboard.json

--- a/apps/youtube/youtube-exporter/app/oci-repository.yaml
+++ b/apps/youtube/youtube-exporter/app/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: youtube-exporter
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref: { tag: 5.1.0 }
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/youtube/youtube-exporter/kustomization.yaml
+++ b/apps/youtube/youtube-exporter/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml


### PR DESCRIPTION
## Summary
- Deploy [youtube-exporter](https://github.com/mirceanton/youtube-exporter) (`v0.1.0`) into the `youtube` namespace as a Prometheus exporter for channel/video stats
- Channel ID and API key are sourced from the `YouTube Data API` 1Password item (`username`/`password`) via ExternalSecret
- ServiceMonitor scrapes `/metrics` on a 5m interval, matching the exporter's default poll interval

## Test plan
- [x] `kustomize build apps/youtube/youtube-exporter/app` renders cleanly
- [x] `kustomize build apps/youtube` confirms the app is wired into the namespace kustomization
- [x] `prettier --check` passes
- [ ] Flux reconciles successfully and metrics show up in Prometheus after merge