### PR TITLE
WIP: deploy claude-remote-control, an always-on Claude Code device

### DIFF
--- a/apps/ai/claude-remote-control/app.ks.yaml
+++ b/apps/ai/claude-remote-control/app.ks.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app claude-remote-control
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: ai
+
+  path: ./apps/ai/claude-remote-control/app
+  components:
+    - ../../../../components/volsync/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      # ~/.claude auth (OAuth login + trust map + user MCP servers) -- small,
+      # but not rebuildable without redoing the interactive /login flow, so
+      # it gets the volsync-backed, off-cluster-backed-up claim.
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: 1password-connect
+      namespace: security-system
+    - name: openebs
+      namespace: storage-system
+    - name: volsync
+      namespace: storage-system

--- a/apps/ai/claude-remote-control/app.ks.yaml
+++ b/apps/ai/claude-remote-control/app.ks.yaml
@@ -22,9 +22,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      # ~/.claude auth (OAuth login + trust map + user MCP servers) -- small,
-      # but not rebuildable without redoing the interactive /login flow, so
-      # it gets the volsync-backed, off-cluster-backed-up claim.
+      # ~/.claude: not rebuildable without redoing the interactive /login flow.
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_PUID: "1000"
       VOLSYNC_PGID: "1000"

--- a/apps/ai/claude-remote-control/app/files/CLAUDE.md
+++ b/apps/ai/claude-remote-control/app/files/CLAUDE.md
@@ -21,7 +21,7 @@ pod restarts (image update, node drain, crash, `kubectl rollout restart`).
 
 ## Kubernetes access is real but read-only
 
-`~/.kube/config` is a working kubeconfig for *this* cluster, scoped to the
+`~/.kube/config` is a working kubeconfig for _this_ cluster, scoped to the
 `claude-remote-control` ServiceAccount bound to the built-in `view`
 ClusterRole: cluster-wide `get`/`list`/`watch` on most resources, and
 notably **no access to Secrets** and **no write access of any kind** --

--- a/apps/ai/claude-remote-control/app/files/CLAUDE.md
+++ b/apps/ai/claude-remote-control/app/files/CLAUDE.md
@@ -1,0 +1,89 @@
+# Operating context: this is the homelab remote-control pod
+
+You are running as the `claude-remote-control` pod in the `ai` namespace of
+Mircea's homelab Kubernetes cluster (Flux-managed GitOps, repo `home-ops`).
+This is **not** an ephemeral local session. You are a single always-on
+`claude remote-control` server process, reachable as a device from the
+Claude mobile app and claude.ai/code, restarted by Kubernetes whenever the
+pod restarts (image update, node drain, crash, `kubectl rollout restart`).
+
+## What persists across restarts, and what doesn't
+
+- `~/.claude` (OAuth login, trust map, user-scope MCP servers) -- persistent
+  volume, backed up off-cluster via VolSync. Survives restarts and node loss.
+- `~/.mise` (mise's data/cache dir -- every tool mise installs) -- persistent
+  volume, not backed up (fully rebuildable). Survives restarts, not node loss.
+- Everything else under `$HOME`, including `~/workspace` -- ephemeral
+  container filesystem. Cloned repos, scratch files, anything you write
+  outside the two paths above disappears on restart. Don't treat it as
+  durable; if something needs to survive, it belongs in a git remote, not
+  this pod's local disk.
+
+## Kubernetes access is real but read-only
+
+`~/.kube/config` is a working kubeconfig for *this* cluster, scoped to the
+`claude-remote-control` ServiceAccount bound to the built-in `view`
+ClusterRole: cluster-wide `get`/`list`/`watch` on most resources, and
+notably **no access to Secrets** and **no write access of any kind** --
+`kubectl apply`, `kubectl delete`, `kubectl edit`, `kubectl exec`, `helm
+install/upgrade`, etc. will all fail with a 403. Use it freely for reading
+cluster state (`kubectl get`, `kubectl describe`, checking Flux
+Kustomization/HelmRelease status, reading pod logs) but don't assume you can
+change anything through it. If a task needs a change applied to the cluster,
+the change goes through this repo (a Flux Kustomization/HelmRelease edit,
+committed and pushed) and Flux reconciles it -- not a direct `kubectl`
+mutation, which would fail anyway and would bypass GitOps even if it didn't.
+
+This is deliberately the starting point, not the ceiling -- if broader
+access turns out to be genuinely needed, that's a decision for Mircea to
+make explicitly (edit `app/rbac.yaml` in this app's directory), not
+something to route around from in here.
+
+## Tool versions are never baked into this image
+
+The container image (`ghcr.io/mirceanton/claude-remote-control`, built from
+the `container-images` repo) intentionally ships almost nothing beyond
+Node.js and the `claude` CLI itself. `kubectl`, `helm`, `flux`, `k9s`,
+`talosctl`, `go`, and everything else resolve **per-repo**, from that
+repo's own `mise.toml`, the moment you `cd` into it -- mise auto-installs
+and auto-trusts on directory change (`MISE_YES`/`MISE_TRUSTED_CONFIG_PATHS`
+are set for this), so you never need to run `mise trust` or `mise install`
+by hand. This means the exact tool version available depends on which repo
+you're standing in -- don't assume a version, check that repo's `mise.toml`
+if it matters.
+
+## Never point this at the LLM gateway
+
+This cluster runs a LiteLLM/Envoy AI gateway (`litellm.ai.svc.cluster.local`,
+`llm.home.mirceanton.com`) that other in-cluster tools use. This pod must
+**never** be pointed at it: no `ANTHROPIC_BASE_URL`, no proxying Claude Code's
+own traffic through it, in a session, a hook, or anything you write to
+`~/.claude/settings.json`. Remote Control requires talking to
+`api.anthropic.com` directly and refuses to start otherwise -- the image
+sets none of the env vars that would break this
+(`ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_USE_BEDROCK`,
+`CLAUDE_CODE_USE_VERTEX`, `DISABLE_TELEMETRY`, `DO_NOT_TRACK`,
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_GROWTHBOOK`), and a
+`CiliumNetworkPolicy` on this pod backs that up at the network level. Treat
+all of that as invariant, not configuration to "fix" if something seems
+inconvenient.
+
+## MCP servers
+
+Configured out-of-band (mounted into `~/.claude.json` at boot from a
+ConfigMap/Secret in this app's directory), not by you editing MCP config by
+hand -- changes belong in that file in git, not in a live `claude mcp add`.
+
+---
+
+## Mircea: fill this in
+
+<!--
+Repos this pod typically works in (so it knows where to look without being
+told each time), and any cluster conventions that aren't obvious purely
+from the RBAC scope above -- Flux reconciliation expectations (e.g. "don't
+wait on `flux reconcile`, it happens automatically within N minutes"),
+naming patterns for new apps, which namespaces are safe to poke around in
+vs. off-limits, where to look first when something's broken, anything else
+you'd want a new teammate to know on day one.
+-->

--- a/apps/ai/claude-remote-control/app/files/mcp-servers.json
+++ b/apps/ai/claude-remote-control/app/files/mcp-servers.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/apps/ai/claude-remote-control/app/helm-release.yaml
+++ b/apps/ai/claude-remote-control/app/helm-release.yaml
@@ -24,15 +24,11 @@ spec:
     controllers:
       claude-remote-control:
         annotations:
-          # Picks up CLAUDE.md / mcp-servers.json edits and kubeconfig
-          # rotation automatically. Both are subPath mounts, which kubelet
-          # does not live-refresh on its own -- this is what actually
-          # applies the change, via a rolling restart.
+          # subPath mounts (CLAUDE.md, mcp-servers.json) don't live-refresh on
+          # their own -- this is what actually applies an edit, via restart.
           reloader.stakater.com/auto: "true"
 
-        # Always exactly 1: both PVCs below are ReadWriteOnce, a second
-        # concurrent replica couldn't attach them anyway, and two servers
-        # sharing one ~/.claude.json would race writing it.
+        # >1 would race writing ~/.claude.json, and both PVCs are ReadWriteOnce anyway.
         replicas: 1
         strategy: RollingUpdate
 
@@ -47,10 +43,9 @@ spec:
               - |
                 set -eu
                 namespace="$(cat /var/run/secrets/claude-sa-token/namespace)"
-                # Deliberately $namespace, not ${namespace}: Flux's
-                # postBuild.substitute rewrites any ${VAR} it finds across
-                # every resource in this Kustomization, and would choke on
-                # an unbraced-only shell var it doesn't recognize.
+                # $namespace, not ${namespace}: Flux's postBuild.substitute
+                # rewrites ${VAR} across this whole Kustomization and would
+                # choke on a shell var it doesn't recognize.
                 cat >/home/claude/.kube/config <<EOF
                 apiVersion: v1
                 kind: Config
@@ -86,12 +81,9 @@ spec:
               repository: ghcr.io/mirceanton/claude-remote-control
               tag: 2.1.257
 
-            # `claude remote-control` server-mode flags -- see
-            # https://code.claude.com/docs/en/remote-control. same-dir
-            # because $HOME/workspace starts as a plain (non-git) directory
-            # on every restart; `worktree` requires a git repo already
-            # checked out there. Bump --capacity for more concurrent
-            # sessions (scale memory limits with it).
+            # same-dir: $HOME/workspace starts as a plain, non-git directory
+            # on every restart, and `worktree` requires one already checked
+            # out. See https://code.claude.com/docs/en/remote-control.
             args:
               - --spawn=same-dir
               - --capacity=4
@@ -127,11 +119,9 @@ spec:
 
             securityContext:
               allowPrivilegeEscalation: false
-              # Not read-only: this is a general-purpose coding agent that
-              # writes broadly under $HOME on the ephemeral root filesystem
-              # (arbitrary repo clones, per-language build/test artifacts,
-              # scratch files) in ways too broad to enumerate as a static
-              # emptyDir allowlist, unlike a typical single-purpose service.
+              # Not read-only: a general-purpose coding agent writes too
+              # broadly under $HOME (repo clones, build artifacts, scratch
+              # files) to enumerate as a static emptyDir allowlist.
               readOnlyRootFilesystem: false
               capabilities: { drop: ["ALL"] }
 
@@ -165,10 +155,8 @@ spec:
             subPath: mcp-servers.json
             readOnly: true
 
-      # Not subPath: kubelet DOES live-refresh a whole-secret mount, so
-      # ~/.kube/config's `tokenFile:` picks up token rotation without a
-      # restart even though the assembled config itself is written once by
-      # the init container above.
+      # Not subPath: kubelet live-refreshes a whole-secret mount, so
+      # `tokenFile:` in the assembled kubeconfig picks up rotation without a restart.
       kubeconfig-source:
         type: secret
         defaultMode: 0440

--- a/apps/ai/claude-remote-control/app/helm-release.yaml
+++ b/apps/ai/claude-remote-control/app/helm-release.yaml
@@ -1,0 +1,192 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app claude-remote-control
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: claude-remote-control
+
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      claude-remote-control:
+        annotations:
+          # Picks up CLAUDE.md / mcp-servers.json edits and kubeconfig
+          # rotation automatically. Both are subPath mounts, which kubelet
+          # does not live-refresh on its own -- this is what actually
+          # applies the change, via a rolling restart.
+          reloader.stakater.com/auto: "true"
+
+        # Always exactly 1: both PVCs below are ReadWriteOnce, a second
+        # concurrent replica couldn't attach them anyway, and two servers
+        # sharing one ~/.claude.json would race writing it.
+        replicas: 1
+        strategy: RollingUpdate
+
+        initContainers:
+          init-kubeconfig:
+            image:
+              repository: docker.io/library/busybox
+              tag: latest
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                namespace="$(cat /var/run/secrets/claude-sa-token/namespace)"
+                # Deliberately $namespace, not ${namespace}: Flux's
+                # postBuild.substitute rewrites any ${VAR} it finds across
+                # every resource in this Kustomization, and would choke on
+                # an unbraced-only shell var it doesn't recognize.
+                cat >/home/claude/.kube/config <<EOF
+                apiVersion: v1
+                kind: Config
+                clusters:
+                  - name: in-cluster
+                    cluster:
+                      server: https://kubernetes.default.svc:443
+                      certificate-authority: /var/run/secrets/claude-sa-token/ca.crt
+                contexts:
+                  - name: in-cluster
+                    context:
+                      cluster: in-cluster
+                      user: claude-remote-control
+                      namespace: $namespace
+                current-context: in-cluster
+                users:
+                  - name: claude-remote-control
+                    user:
+                      tokenFile: /var/run/secrets/claude-sa-token/token
+                EOF
+                chmod 0600 /home/claude/.kube/config
+            resources:
+              requests: { cpu: 10m, memory: 16Mi }
+              limits: { memory: 32Mi }
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/mirceanton/claude-remote-control
+              tag: 2.1.257
+
+            # `claude remote-control` server-mode flags -- see
+            # https://code.claude.com/docs/en/remote-control. same-dir
+            # because $HOME/workspace starts as a plain (non-git) directory
+            # on every restart; `worktree` requires a git repo already
+            # checked out there. Bump --capacity for more concurrent
+            # sessions (scale memory limits with it).
+            args:
+              - --spawn=same-dir
+              - --capacity=4
+              - --name=homelab-cluster
+
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["pgrep", "-f", "remote-control"]
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["pgrep", "-f", "remote-control"]
+                  failureThreshold: 30
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 4Gi # scale up with --capacity above
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              # Not read-only: this is a general-purpose coding agent that
+              # writes broadly under $HOME on the ephemeral root filesystem
+              # (arbitrary repo clones, per-language build/test artifacts,
+              # scratch files) in ways too broad to enumerate as a static
+              # emptyDir allowlist, unlike a typical single-purpose service.
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+
+    global:
+      createDefaultServiceAccount: false
+
+    persistence:
+      mise-cache:
+        existingClaim: claude-remote-control-mise-cache
+        globalMounts:
+          - path: /home/claude/.mise
+
+      claude-creds:
+        existingClaim: *app
+        globalMounts:
+          - path: /home/claude/.claude
+
+      claude-md:
+        type: configMap
+        name: claude-remote-control-claude-md
+        globalMounts:
+          - path: /home/claude/.claude/CLAUDE.md
+            subPath: CLAUDE.md
+            readOnly: true
+
+      mcp-config:
+        type: configMap
+        name: claude-remote-control-mcp-config
+        globalMounts:
+          - path: /etc/claude/mcp-servers.json
+            subPath: mcp-servers.json
+            readOnly: true
+
+      # Not subPath: kubelet DOES live-refresh a whole-secret mount, so
+      # ~/.kube/config's `tokenFile:` picks up token rotation without a
+      # restart even though the assembled config itself is written once by
+      # the init container above.
+      kubeconfig-source:
+        type: secret
+        defaultMode: 0440
+        name: claude-remote-control-sa-token
+        advancedMounts:
+          claude-remote-control:
+            init-kubeconfig:
+              - path: /var/run/secrets/claude-sa-token
+                readOnly: true
+            app:
+              - path: /var/run/secrets/claude-sa-token
+                readOnly: true
+
+      kube-dir:
+        type: emptyDir
+        advancedMounts:
+          claude-remote-control:
+            init-kubeconfig:
+              - path: /home/claude/.kube
+            app:
+              - path: /home/claude/.kube

--- a/apps/ai/claude-remote-control/app/kustomization.yaml
+++ b/apps/ai/claude-remote-control/app/kustomization.yaml
@@ -10,11 +10,8 @@ resources:
   - ./networkpolicy.yaml
 
 configMapGenerator:
-  # substitute: disabled on both -- CLAUDE.md is meant to be hand-edited
-  # later (see its "fill this in" section) and mcp-servers.json is meant to
-  # gain real server configs, either of which could plausibly end up
-  # containing literal ${VAR} text that Flux would otherwise try to
-  # rewrite.
+  # substitute: disabled -- both files are meant to be hand-edited later and
+  # could plausibly contain literal ${VAR} text that Flux would otherwise rewrite.
   - name: claude-remote-control-claude-md
     options:
       disableNameSuffixHash: true

--- a/apps/ai/claude-remote-control/app/kustomization.yaml
+++ b/apps/ai/claude-remote-control/app/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./rbac.yaml
+  - ./mise-cache.pvc.yaml
+  - ./networkpolicy.yaml
+
+configMapGenerator:
+  # substitute: disabled on both -- CLAUDE.md is meant to be hand-edited
+  # later (see its "fill this in" section) and mcp-servers.json is meant to
+  # gain real server configs, either of which could plausibly end up
+  # containing literal ${VAR} text that Flux would otherwise try to
+  # rewrite.
+  - name: claude-remote-control-claude-md
+    options:
+      disableNameSuffixHash: true
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
+    files:
+      - CLAUDE.md=./files/CLAUDE.md
+
+  - name: claude-remote-control-mcp-config
+    options:
+      disableNameSuffixHash: true
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
+    files:
+      - mcp-servers.json=./files/mcp-servers.json

--- a/apps/ai/claude-remote-control/app/mise-cache.pvc.yaml
+++ b/apps/ai/claude-remote-control/app/mise-cache.pvc.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/v1/persistentvolumeclaim.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: claude-remote-control-mise-cache
+spec:
+  storageClassName: openebs-zfs-cache
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests: { storage: 10Gi }

--- a/apps/ai/claude-remote-control/app/networkpolicy.yaml
+++ b/apps/ai/claude-remote-control/app/networkpolicy.yaml
@@ -1,8 +1,7 @@
 ---
-# First CiliumNetworkPolicy in this cluster -- nowhere else selects pods on
-# egress, so this affects only claude-remote-control. Verify
-# `kubectl get crd ciliumnetworkpolicies.cilium.io` exists and check Hubble
-# flows after the first deploy before assuming this is airtight.
+# First CiliumNetworkPolicy in this cluster. Verify
+# `kubectl get crd ciliumnetworkpolicies.cilium.io` and check Hubble flows
+# after the first deploy before assuming this is airtight.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -13,9 +12,8 @@ spec:
       app.kubernetes.io/name: claude-remote-control
 
   egress:
-    # DNS -- both to resolve anything below, and because Cilium's DNS proxy
-    # needs to observe the query to learn the FQDN -> IP mapping the
-    # api.anthropic.com rule relies on.
+    # Cilium's DNS proxy must observe the query to learn the FQDN -> IP
+    # mapping the api.anthropic.com rule below relies on.
     - toEndpoints:
         - matchLabels:
             "k8s:io.kubernetes.pod.namespace": kube-system
@@ -28,13 +26,12 @@ spec:
             dns:
               - matchPattern: "*"
 
-    # Kubernetes API server, for the read-only kubeconfig.
+    # For the read-only kubeconfig.
     - toEntities:
         - kube-apiserver
 
-    # api.anthropic.com specifically -- guaranteed reachable regardless of
-    # the broader world rule below. This is the one destination Claude Code
-    # itself actually needs.
+    # The one destination Claude Code itself actually needs -- guaranteed
+    # reachable regardless of the broader world rule below.
     - toFQDNs:
         - matchName: api.anthropic.com
       toPorts:
@@ -42,14 +39,12 @@ spec:
             - port: "443"
               protocol: TCP
 
-    # Everything else this agent legitimately needs as a coding agent: git
-    # clone, whatever registries a repo's own tooling pulls from, mise
-    # fetching tool releases pinned by each repo's own mise.toml. Port-scoped
-    # to plain web traffic only (no arbitrary TCP/UDP), and `world` in Cilium
-    # means outside-the-cluster -- there is deliberately no toEndpoints /
-    # toServices rule for litellm or anything else in-cluster, so it stays
-    # unreachable from this pod regardless of this rule's breadth, and its
-    # port 4000 is never opened either way.
+    # Everything else this agent needs as a coding agent (git, registries,
+    # mise fetching tools pinned by each repo's own mise.toml), port-scoped to
+    # plain web traffic only. `world` in Cilium means outside-the-cluster --
+    # there is deliberately no toEndpoints/toServices rule for litellm or
+    # anything else in-cluster, so it stays unreachable regardless of this
+    # rule's breadth, and its port 4000 is never opened either way.
     - toEntities:
         - world
       toPorts:

--- a/apps/ai/claude-remote-control/app/networkpolicy.yaml
+++ b/apps/ai/claude-remote-control/app/networkpolicy.yaml
@@ -1,0 +1,62 @@
+---
+# First CiliumNetworkPolicy in this cluster -- nowhere else selects pods on
+# egress, so this affects only claude-remote-control. Verify
+# `kubectl get crd ciliumnetworkpolicies.cilium.io` exists and check Hubble
+# flows after the first deploy before assuming this is airtight.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: claude-remote-control
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: claude-remote-control
+
+  egress:
+    # DNS -- both to resolve anything below, and because Cilium's DNS proxy
+    # needs to observe the query to learn the FQDN -> IP mapping the
+    # api.anthropic.com rule relies on.
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
+
+    # Kubernetes API server, for the read-only kubeconfig.
+    - toEntities:
+        - kube-apiserver
+
+    # api.anthropic.com specifically -- guaranteed reachable regardless of
+    # the broader world rule below. This is the one destination Claude Code
+    # itself actually needs.
+    - toFQDNs:
+        - matchName: api.anthropic.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+
+    # Everything else this agent legitimately needs as a coding agent: git
+    # clone, whatever registries a repo's own tooling pulls from, mise
+    # fetching tool releases pinned by each repo's own mise.toml. Port-scoped
+    # to plain web traffic only (no arbitrary TCP/UDP), and `world` in Cilium
+    # means outside-the-cluster -- there is deliberately no toEndpoints /
+    # toServices rule for litellm or anything else in-cluster, so it stays
+    # unreachable from this pod regardless of this rule's breadth, and its
+    # port 4000 is never opened either way.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+
+  ingress: []

--- a/apps/ai/claude-remote-control/app/oci-repository.yaml
+++ b/apps/ai/claude-remote-control/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: claude-remote-control
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.1.0
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/ai/claude-remote-control/app/rbac.yaml
+++ b/apps/ai/claude-remote-control/app/rbac.yaml
@@ -1,0 +1,35 @@
+---
+# Read-only, cluster-wide access for the agent's ~/.kube/config, via the
+# built-in `view` ClusterRole (get/list/watch on most objects; notably
+# excludes Secrets). Expand later by swapping the roleRef for a custom
+# ClusterRole once more access is actually needed.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: claude-remote-control
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: claude-remote-control-view
+subjects:
+  - kind: ServiceAccount
+    name: claude-remote-control
+    namespace: ai
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io
+---
+# Explicit, long-lived token for the ServiceAccount above (Kubernetes no
+# longer auto-creates these since 1.24). Not sensitive at rest in git: the
+# `token`/`ca.crt`/`namespace` keys are populated by the control plane after
+# creation, this manifest carries none of them. The init container in
+# helm-release.yaml assembles ~/.kube/config from this at pod startup.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: claude-remote-control-sa-token
+  annotations:
+    kubernetes.io/service-account.name: claude-remote-control
+type: kubernetes.io/service-account-token

--- a/apps/ai/claude-remote-control/app/rbac.yaml
+++ b/apps/ai/claude-remote-control/app/rbac.yaml
@@ -1,8 +1,6 @@
 ---
-# Read-only, cluster-wide access for the agent's ~/.kube/config, via the
-# built-in `view` ClusterRole (get/list/watch on most objects; notably
-# excludes Secrets). Expand later by swapping the roleRef for a custom
-# ClusterRole once more access is actually needed.
+# Read-only, cluster-wide, via the built-in `view` ClusterRole (no Secrets,
+# no writes). Swap the roleRef below for a custom ClusterRole to expand later.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -21,11 +19,9 @@ roleRef:
   name: view
   apiGroup: rbac.authorization.k8s.io
 ---
-# Explicit, long-lived token for the ServiceAccount above (Kubernetes no
-# longer auto-creates these since 1.24). Not sensitive at rest in git: the
-# `token`/`ca.crt`/`namespace` keys are populated by the control plane after
-# creation, this manifest carries none of them. The init container in
-# helm-release.yaml assembles ~/.kube/config from this at pod startup.
+# Long-lived token for the ServiceAccount above (k8s stopped auto-creating
+# these in 1.24). Safe to commit unencrypted: token/ca.crt/namespace are
+# populated by the control plane, not by this manifest.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/apps/ai/claude-remote-control/kustomization.yaml
+++ b/apps/ai/claude-remote-control/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/ai/kustomization.yaml
+++ b/apps/ai/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./namespace.yaml
   - ./grafana-folder.yaml
 
+  - ./claude-remote-control
   - ./github-mcp
   - ./hermano
   - ./hermes


### PR DESCRIPTION
## Summary

Deploys `ghcr.io/mirceanton/claude-remote-control` (`claude remote-control` server mode, built in the companion `container-images` PR) as a single-replica `app-template` HelmRelease in the `ai` namespace, so it shows up as a persistent device in the Claude mobile app / claude.ai/code — the same as a laptop running `claude remote-control` would, but always on.

- **Two PVCs**: a plain `openebs-zfs-cache` claim for mise's tool cache (rebuildable, no backup), and a VolSync-backed claim for `~/.claude` (OAuth login + trust map + MCP servers — not worth losing to a node failure, and reuses the existing shared restic/Garage backup credentials, no new 1Password item needed).
- **Read-only Kubernetes access**: a dedicated `ServiceAccount` bound to the built-in `view` ClusterRole (cluster-wide `get`/`list`/`watch`, no Secrets, no writes). An init container assembles `~/.kube/config` at startup from that ServiceAccount's token Secret using `tokenFile:`, so kubelet's live refresh of the token carries through without needing a pod restart.
- **CLAUDE.md** and a placeholder MCP server config, each their own `ConfigMap`, mounted via `subPath` and picked up on edit via the existing `reloader.stakater.com/auto` annotation (subPath mounts don't live-refresh on their own, so this is what actually applies a CLAUDE.md edit).
- **NetworkPolicy**: this cluster's first `CiliumNetworkPolicy`, scoped to just this pod — DNS, the in-cluster API server, an explicit `api.anthropic.com:443` allow, and broad-but-port-scoped (80/443 only) outbound web for everything else this agent legitimately needs (git, registries, mise's own tool downloads for whatever repo it's in). Deliberately no `toEndpoints`/`toServices` rule for `litellm` or anything else in-cluster, so the AI gateway stays unreachable from this pod regardless of how broad that last rule is.
- Registered in `apps/ai/kustomization.yaml`, alphabetically.

## Manual steps needed before this is usable

1. **Image must exist first**: the HelmRelease pins `ghcr.io/mirceanton/claude-remote-control:2.1.257` — until the companion `container-images` PR merges and CI builds it, expect `ImagePullBackOff`, not a bug.
2. **One-off interactive login**: `~/.claude` starts empty. Needs a temporary debug pod mounting the same PVC (`claude-remote-control`) to run `claude /login` interactively before the real pod will authenticate — e.g.:
   ```
   kubectl run -it --rm claude-login -n ai \
     --image=ghcr.io/mirceanton/claude-remote-control:2.1.257 \
     --overrides='{"spec":{"containers":[{"name":"claude-login","image":"ghcr.io/mirceanton/claude-remote-control:2.1.257","command":["bash"],"stdin":true,"tty":true,"volumeMounts":[{"name":"creds","mountPath":"/home/claude/.claude"}]}],"volumes":[{"name":"creds","persistentVolumeClaim":{"claimName":"claude-remote-control"}}]}}'
   ```
3. **CLAUDE.md has a "fill this in" section** at the bottom (which repos it typically works in, cluster conventions not obvious from RBAC alone) — worth filling in before/after merge, not blocking.

## Marked as draft / WIP because

- The `CiliumNetworkPolicy` is genuinely untested — first one in this cluster (`toFQDNs`/`toEntities` combo, `l7Proxy: false` interaction). Worth confirming `kubectl get crd ciliumnetworkpolicies.cilium.io` exists and watching Hubble flows after first deploy before trusting it's airtight.
- Depends on the companion `container-images` PR actually being built and published first.
- The kubeconfig-assembly approach (init container + auto-populated ServiceAccount token, rather than a static kubeconfig Secret) is a deliberate deviation worth a second look before this is considered final.

## Test plan

- [ ] Companion `container-images` PR merged and image published
- [ ] `task lint:check` passes
- [ ] Flux reconciles the Kustomization/HelmRelease cleanly
- [ ] `kubectl exec` (or the init container's logs) confirm `~/.kube/config` is assembled correctly and `kubectl get pods` works read-only from inside the pod
- [ ] Confirm the NetworkPolicy doesn't block anything unexpected (Hubble flow check)
- [ ] One-off `claude /login`, then confirm the session shows up in the Claude mobile app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uL3RnsDzH2TygBxBsNtV8

---
_Generated by [Claude Code](https://claude.ai/code/session_014uL3RnsDzH2TygBxBsNtV8)_