### PR TITLE
fix(hermano): scale down to 0 replicas

### DIFF
--- a/apps/ai/hermano/app/helm-release.yaml
+++ b/apps/ai/hermano/app/helm-release.yaml
@@ -19,7 +19,7 @@ spec:
 
     controllers:
       hermano:
-        replicas: 1
+        replicas: 0
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Summary
- Scale `hermano` down to 0 replicas due to upstream registry issues causing a flood of alerts it cannot remediate.

## Test plan
- [x] `prettier --check` passes on the modified file
- [ ] CI lint passes

This will be merged automatically once lint passes. A follow-up PR will be opened to scale `hermano` back up to 1 replica once the registry issue is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7Ay2FnasRjNNvTTVKXKao

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7Ay2FnasRjNNvTTVKXKao)_