### PR TITLE
fix(hermano): scale back up to 1 replica

### DIFF
--- a/apps/ai/hermano/app/helm-release.yaml
+++ b/apps/ai/hermano/app/helm-release.yaml
@@ -19,7 +19,7 @@ spec:
 
     controllers:
       hermano:
-        replicas: 0
+        replicas: 1
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Summary
- Revert #1073: scale `hermano` back up to 1 replica.

This PR is intentionally left open. It's scheduled to be merged tomorrow at 11:00 (Europe/Bucharest) once the upstream registry issue has had time to settle — merge sooner if it's confirmed fixed before then.

## Test plan
- [x] `prettier --check` passes on the modified file
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7Ay2FnasRjNNvTTVKXKao

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7Ay2FnasRjNNvTTVKXKao)_