### PR TITLE
feat: deploy arr-hub

### DIFF
--- a/apps/downloads/arr-hub/app.ks.yaml
+++ b/apps/downloads/arr-hub/app.ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app arr-hub
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: downloads
+
+  path: ./apps/downloads/arr-hub/app
+  components:
+    - ../../../../components/volsync/
+    - ../../../../components/keycloak-client/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 256Mi
+      VOLSYNC_PUID: "1001"
+      VOLSYNC_PGID: "1001"
+
+  decryption: { provider: sops }
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/downloads/arr-hub/app/external-secret.yaml
+++ b/apps/downloads/arr-hub/app/external-secret.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name arr-hub-secret
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  data:
+    - secretKey: SESSION_SECRET
+      remoteRef:
+        key: Arr Hub Session Secret
+        property: password
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: Sonarr API Key
+        property: password
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: Radarr API Key
+        property: password
+    - secretKey: LIDARR_API_KEY
+      remoteRef:
+        key: Lidarr API Key
+        property: password
+    - secretKey: BAZARR_API_KEY
+      remoteRef:
+        key: Bazarr API Key
+        property: password
+    - secretKey: PROWLARR_API_KEY
+      remoteRef:
+        key: Prowlarr API Key
+        property: password

--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -1,0 +1,148 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app arr-hub
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: arr-hub
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      arr-hub:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/mirceanton/arr-hub
+              tag: v0.1.0
+
+            env:
+              DATABASE_URL: file:/data/app.db
+              PORT: &port 3000
+              LOG_LEVEL: info
+
+              # This app owns its full OIDC login flow (session cookies, its
+              # own permission model keyed off group claims) rather than
+              # relying on gateway-level auth, so it's deliberately not
+              # behind the components/oidc SecurityPolicy like the other
+              # apps in this namespace — only components/keycloak-client is
+              # used, to provision the client-id/secret below.
+              OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
+              OIDC_REDIRECT_URI: "https://${APP}.home.mirceanton.com/api/auth/callback/keycloak"
+              OIDC_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: "${APP}-oidc-secret"
+                    key: client-id
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: "${APP}-oidc-secret"
+                    key: client-secret
+
+              SESSION_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: SESSION_SECRET
+
+              SONARR_URL: http://sonarr:8989
+              SONARR_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: SONARR_API_KEY
+              RADARR_URL: http://radarr:7878
+              RADARR_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: RADARR_API_KEY
+              LIDARR_URL: http://lidarr:8686
+              LIDARR_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: LIDARR_API_KEY
+              BAZARR_URL: http://bazarr:6767
+              BAZARR_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: BAZARR_API_KEY
+              PROWLARR_URL: http://prowlarr:9696
+              PROWLARR_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: PROWLARR_API_KEY
+
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        # The image's own Dockerfile creates and runs as a fixed uid/gid
+        # 1001 (`adduser --uid 1001 arrhub`) — this must match, not the
+        # usual home-operations 568 convention, since this is a bespoke
+        # image rather than a home-operations-published one.
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+
+    route:
+      home:
+        hostnames: ["${APP}.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      # DATABASE_URL=file:/data/app.db — the sqlite db plus drizzle's WAL
+      # files live here; migrations run automatically on container start.
+      config:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/apps/downloads/arr-hub/app/kustomization.yaml
+++ b/apps/downloads/arr-hub/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/downloads/arr-hub/app/oci-repository.yaml
+++ b/apps/downloads/arr-hub/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: arr-hub
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.1.0
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/downloads/arr-hub/kustomization.yaml
+++ b/apps/downloads/arr-hub/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/downloads/kustomization.yaml
+++ b/apps/downloads/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: downloads
 resources:
   - ./namespace.yaml
   - ./grafana-folder.yaml
+  - ./arr-hub
   - ./bazarr
   - ./flaresolverr
   - ./lidarr


### PR DESCRIPTION
## Summary

Deploys [arr-hub](https://github.com/mirceanton/arr-hub) to the `downloads` namespace — a single login/permission front door for Sonarr, Radarr, Lidarr, Bazarr, and Prowlarr.

- SQLite-backed via a small (256Mi) volsync PVC, standard backup/restore.
- Runs its own full OIDC login flow (session cookies, per-user permissions keyed off group claims) rather than gateway-level auth — only `components/keycloak-client` is used (for the client-id/secret), deliberately **not** `components/oidc` like the other apps in this namespace, to avoid double-login.
- *arr API keys reuse the existing 1Password items (`Sonarr API Key`, `Radarr API Key`, `Lidarr API Key`, `Prowlarr API Key`).
- LAN-only route (`envoy-internal`), matching the other apps in this namespace.

## Before merging

Two 1Password items need to exist for this to come up healthy (ExternalSecret will just fail to sync otherwise, not fatal):
- [ ] `Bazarr API Key` (property: `password`) — no existing item since nothing else here talks to Bazarr's API yet.
- [ ] `Arr Hub Session Secret` (property: `password`) — new random 32+ char value, e.g. `openssl rand -hex 32`.

## Test plan

- [x] `task lint:check` passes (prettier + actionlint)
- [x] `kustomize build apps/downloads` includes the new Flux Kustomization
- [x] `kustomize build apps/downloads/arr-hub/app` renders ExternalSecret/HelmRelease/OCIRepository cleanly
- [ ] Add the two 1Password items above
- [ ] Merge, watch `flux get kustomization arr-hub -n downloads` and `kubectl -n downloads get pods -l app.kubernetes.io/name=arr-hub`

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh