### PR TITLE
fix(arr-hub): generate SESSION_SECRET instead of storing it in 1Password

### DIFF
--- a/apps/downloads/arr-hub/app/external-secret.yaml
+++ b/apps/downloads/arr-hub/app/external-secret.yaml
@@ -16,10 +16,6 @@ spec:
     creationPolicy: Owner
 
   data:
-    - secretKey: SESSION_SECRET
-      remoteRef:
-        key: Arr Hub Session Secret
-        property: password
     - secretKey: SONARR_API_KEY
       remoteRef:
         key: Sonarr API Key

--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -51,8 +51,8 @@ spec:
               SESSION_SECRET:
                 valueFrom:
                   secretKeyRef:
-                    name: arr-hub-secret
-                    key: SESSION_SECRET
+                    name: arr-hub-session-secret
+                    key: password
 
               SONARR_URL: http://sonarr:8989
               SONARR_API_KEY:

--- a/apps/downloads/arr-hub/app/kustomization.yaml
+++ b/apps/downloads/arr-hub/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
   - ./external-secret.yaml
+  - ./session-secret.yaml

--- a/apps/downloads/arr-hub/app/session-secret.yaml
+++ b/apps/downloads/arr-hub/app/session-secret.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: arr-hub-session-secret
+spec:
+  length: 64
+  digits: 10
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name arr-hub-session-secret
+spec:
+  refreshInterval: "0"
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: arr-hub-session-secret


### PR DESCRIPTION
## Summary

Follow-up to #1104. Replaces the 1Password-backed `SESSION_SECRET` with an ESO `Password` generator, matching how `hermano` and `modelhub` already handle their own session secrets in this cluster.

- `refreshInterval: "0"` — generated once, then stable forever. Regenerating on every refresh would invalidate every active session.
- One less 1Password item needed before arr-hub comes up healthy — only `Bazarr API Key` is still needed.

## Test plan

- [x] `task lint:check` passes
- [x] `kustomize build apps/downloads/arr-hub/app` renders all 5 resources (ExternalSecret x2, Password generator, HelmRelease, OCIRepository)

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh