### PR TITLE
fix(arr-hub): route on downloads.home.mirceanton.com

### DIFF
--- a/apps/downloads/arr-hub/app.ks.yaml
+++ b/apps/downloads/arr-hub/app.ks.yaml
@@ -26,6 +26,10 @@ spec:
       VOLSYNC_CAPACITY: 256Mi
       VOLSYNC_PUID: "1001"
       VOLSYNC_PGID: "1001"
+      #? arr-hub is the landing page for the downloads namespace, not "arr-hub.home.mirceanton.com"
+      KEYCLOAK_CLIENT_HOME_URL: "https://downloads.home.mirceanton.com"
+      KEYCLOAK_CLIENT_REDIRECT_URL: "https://downloads.home.mirceanton.com/*"
+      KEYCLOAK_CLIENT_WEB_ORIGIN: "https://downloads.home.mirceanton.com"
 
   decryption: { provider: sops }
   dependsOn:

--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -36,7 +36,7 @@ spec:
               # apps in this namespace — only components/keycloak-client is
               # used, to provision the client-id/secret below.
               OIDC_ISSUER_URL: https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab
-              OIDC_REDIRECT_URI: "https://${APP}.home.mirceanton.com/api/auth/callback/keycloak"
+              OIDC_REDIRECT_URI: "https://downloads.home.mirceanton.com/api/auth/callback/keycloak"
               OIDC_CLIENT_ID:
                 valueFrom:
                   secretKeyRef:
@@ -130,7 +130,7 @@ spec:
 
     route:
       home:
-        hostnames: ["${APP}.home.mirceanton.com"]
+        hostnames: ["downloads.home.mirceanton.com"]
         parentRefs:
           - name: envoy-internal
             namespace: network-system


### PR DESCRIPTION
## Summary

arr-hub was deployed at `arr-hub.home.mirceanton.com` (the default `${APP}`-derived hostname), but it's meant to be the landing page for the whole `downloads` namespace, at `downloads.home.mirceanton.com`.

Fixes:
- HTTPRoute hostname
- `OIDC_REDIRECT_URI` env var
- Keycloak client's home URL / redirect URI / web origin (via the `keycloak-client` component's override vars, same pattern used by grafana/headlamp/immich/etc.)

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh