### PR TITLE
fix(container): update ghcr.io/mirceanton/arr-hub ( v0.1.0 → v0.1.1 )

### DIFF
--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/arr-hub
-              tag: v0.1.0
+              tag: v0.1.1
 
             env:
               DATABASE_URL: file:/data/app.db


### PR DESCRIPTION
Picks up mirceanton/arr-hub#6 — fixes OIDC post-login redirecting to `localhost` instead of the app's real hostname.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh