### PR TITLE
fix(container): update ghcr.io/mirceanton/arr-hub ( v0.1.1 → v0.1.2 )

### DIFF
--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/arr-hub
-              tag: v0.1.1
+              tag: v0.1.2
 
             env:
               DATABASE_URL: file:/data/app.db


### PR DESCRIPTION
Picks up mirceanton/arr-hub#7 — fixes OIDC token exchange failing with `invalid_grant: Incorrect redirect_uri`.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh