### PR TITLE
fix(bookorbit): register legacy hostname as valid OAuth redirect URI

### DIFF
--- a/apps/media/bookorbit/app/kustomization.yaml
+++ b/apps/media/bookorbit/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 patchesStrategicMerge:
   - ./patches/cnpg.yaml
+  - ./patches/keycloak-client.yaml

--- a/apps/media/bookorbit/app/patches/keycloak-client.yaml
+++ b/apps/media/bookorbit/app/patches/keycloak-client.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/keycloak.hostzero.com/keycloakclient_v1beta1.json
+# The HTTPRoute serves both hostnames (bookorbit.home.mirceanton.com is a legacy alias for
+# books.home.mirceanton.com), and BookOrbit builds its OAuth redirect_uri from whichever
+# hostname the browser actually used — so both must be registered or logins via the old
+# hostname fail with invalid_redirect_uri.
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakClient
+metadata:
+  name: ${APP}
+spec:
+  definition:
+    redirectUris:
+      - https://books.home.mirceanton.com/*
+      - https://bookorbit.home.mirceanton.com/*
+    webOrigins:
+      - https://books.home.mirceanton.com
+      - https://bookorbit.home.mirceanton.com


### PR DESCRIPTION
## Summary

Keycloak logged `LOGIN_ERROR`/`invalid_redirect_uri` for bookorbit:
```
error="invalid_redirect_uri", redirect_uri="https://bookorbit.home.mirceanton.com/oauth2-callback"
```

The HTTPRoute serves both `bookorbit.home.mirceanton.com` (legacy) and `books.home.mirceanton.com` (canonical, matches `APP_URL`), but the KeycloakClient only had the canonical one in `redirectUris`/`webOrigins`. BookOrbit evidently derives its OAuth redirect_uri from the browser's actual Host header rather than its configured `APP_URL`, so anyone reaching it via the legacy hostname (old bookmark, browser autocomplete, etc.) gets a broken login.

Fix: a Kustomize patch on the generated `KeycloakClient` (following the existing `patches/cnpg.yaml` pattern in this app) adds the legacy hostname to both `redirectUris` and `webOrigins`, matching what the HTTPRoute already actually serves.

Verified the patch applies correctly with a local `kubectl kustomize` build (component + patch merged exactly as Flux would).

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh