### PR TITLE
feat(paperless): allow social account auto-signup via Keycloak

### DIFF
--- a/apps/media/paperless/app/helm-release.yaml
+++ b/apps/media/paperless/app/helm-release.yaml
@@ -50,7 +50,7 @@ spec:
               PAPERLESS_TASK_WORKERS: "2"
               # Authentication
               PAPERLESS_ACCOUNT_ALLOW_SIGNUPS: "false"
-              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "false"
+              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "true"
               PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
               PAPERLESS_DISABLE_REGULAR_LOGIN: "true"
               PAPERLESS_OIDC_CLIENT_ID:


### PR DESCRIPTION
## Summary

`PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS` was `false`, and since `PAPERLESS_DISABLE_REGULAR_LOGIN=true` leaves no password-login fallback, only a user with an already-linked `SocialAccount` row could get in. That broke:
- Existing users (`mirk`) whose Keycloak `sub` changed when LDAP users were recreated — their stored link is now stale.
- Any user (`bomkii`, `csoare`, `cristig`) who's never logged into Paperless before and has no link at all.

Enabling auto-signup means allauth will auto-connect a matching-email existing account, or create a new one for a first-time Keycloak login, on demand — per user's explicit request to leave this on going forward so new LDAP/Keycloak users don't need manual account provisioning in Paperless.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh