### PR TITLE
chore(qui): drop legacy torrent.home.mirceanton.com hostname

### DIFF
--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -115,7 +115,7 @@ services:
     items:
       - name: "Qui"
         subtitle: "Torrent Client"
-        url: "https://torrent.home.mirceanton.com"
+        url: "https://qui.home.mirceanton.com"
         target: "_blank"
         logo: "assets/icons/webp/qui.webp"
 

--- a/apps/downloads/qui/app/helm-release.yaml
+++ b/apps/downloads/qui/app/helm-release.yaml
@@ -87,7 +87,7 @@ spec:
 
     route:
       home:
-        hostnames: ["torrent.home.mirceanton.com", "qui.home.mirceanton.com"]
+        hostnames: ["qui.home.mirceanton.com"]
         parentRefs:
           - name: envoy-internal
             namespace: network-system


### PR DESCRIPTION
## Summary

Per request, trimming qui down to a single canonical hostname (`qui.home.mirceanton.com`), matching the pattern already applied to bookorbit/immich. Unlike bookorbit, this is purely cosmetic — qui's `QUI__OIDC_REDIRECT_URL` was already statically pinned to `qui.home.mirceanton.com` (not derived from the browser's Host header), and its KeycloakClient was already only registered for that hostname, so nothing OAuth-related was depending on `torrent.home.mirceanton.com`.

Homer's dashboard link updated to match.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh