### PR TITLE
feat(homer): add arr-hub to the dashboard

### DIFF
--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -113,6 +113,11 @@ services:
   - name: "Downloads"
     icon: "fa-solid fa-skull-crossbones"
     items:
+      - name: "Downloads Manager"
+        subtitle: "Arr Suite Hub"
+        url: "https://downloads.home.mirceanton.com"
+        target: "_blank"
+
       - name: "Qui"
         subtitle: "Torrent Client"
         url: "https://qui.home.mirceanton.com"


### PR DESCRIPTION
## Summary

Adds arr-hub to the Downloads section, titled "Downloads Manager", linking to https://downloads.home.mirceanton.com — listed first as the hub/landing entry ahead of the individual *arr services.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh