### PR TITLE
chore(homer): pirate-flag icon for arr-hub, drop subtitle

### DIFF
--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -114,7 +114,7 @@ services:
     icon: "fa-solid fa-skull-crossbones"
     items:
       - name: "Downloads Manager"
-        subtitle: "Arr Suite Hub"
+        icon: "fa-solid fa-skull-crossbones"
         url: "https://downloads.home.mirceanton.com"
         target: "_blank"
 


### PR DESCRIPTION
Per request — uses the skull-crossbones icon (Font Awesome has no dedicated "pirate flag" glyph; this is the closest, and it's already what the Downloads section header itself uses) and drops the subtitle.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh