### PR TITLE
feat(container): update ghcr.io/mirceanton/arr-hub ( v0.1.2 → v0.2.0 )

### DIFF
--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/arr-hub
-              tag: v0.1.2
+              tag: v0.2.0
 
             env:
               DATABASE_URL: file:/data/app.db


### PR DESCRIPTION
Picks up mirceanton/arr-hub#8 — renames Keycloak role-mapping groups to `arr-admin`/`arr-requester`/`arr-viewer`, adds a read-only banner for viewers, and makes the app title configurable via `APP_TITLE` (left unset, defaults to "Arr Hub").

Note: you'll need to create `arr-admin`/`arr-requester`/`arr-viewer` groups in Keycloak/LDAP for the role mapping to actually apply to anyone.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh