### PR TITLE
feat(arr-hub): provision Keycloak groups for role mapping via CRD

### DIFF
--- a/apps/downloads/arr-hub/app/keycloak-groups.yaml
+++ b/apps/downloads/arr-hub/app/keycloak-groups.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/keycloak.hostzero.com/keycloakgroup_v1beta1.json
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakGroup
+metadata:
+  name: arr-admin
+spec:
+  name: arr-admin
+  clusterRealmRef:
+    name: homelab
+  definition: {}
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/keycloak.hostzero.com/keycloakgroup_v1beta1.json
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakGroup
+metadata:
+  name: arr-requester
+spec:
+  name: arr-requester
+  clusterRealmRef:
+    name: homelab
+  definition: {}
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/keycloak.hostzero.com/keycloakgroup_v1beta1.json
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakGroup
+metadata:
+  name: arr-viewer
+spec:
+  name: arr-viewer
+  clusterRealmRef:
+    name: homelab
+  definition: {}

--- a/apps/downloads/arr-hub/app/kustomization.yaml
+++ b/apps/downloads/arr-hub/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helm-release.yaml
   - ./external-secret.yaml
   - ./session-secret.yaml
+  - ./keycloak-groups.yaml


### PR DESCRIPTION
## Summary

arr-hub's Keycloak group -> role mapping (mirceanton/arr-hub#8) expects `arr-admin`, `arr-requester`, `arr-viewer` to exist as Keycloak groups, but nothing provisions them yet.

Per request, using the `KeycloakGroup` CRD directly rather than the LLDAP Terraform module — checked, and no other app in this repo currently manages Keycloak groups this way (`kubectl get keycloakgroups -A` was empty before this PR). These are pure Keycloak-side role labels with no underlying LDAP/directory meaning, so a CRD alongside the app's own KeycloakClient made more sense than adding them to the LDAP `groups` variable.

Three top-level `KeycloakGroup` resources under the `homelab` `ClusterKeycloakRealm`, added to arr-hub's own app kustomization.

Verified the resulting manifests with a local `kubectl kustomize` build.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh