### PR TITLE
feat(container): update ghcr.io/mirceanton/arr-hub ( v0.2.0 → v0.3.0 )

### DIFF
--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/arr-hub
-              tag: v0.2.0
+              tag: v0.3.0
 
             env:
               DATABASE_URL: file:/data/app.db


### PR DESCRIPTION
Picks up mirceanton/arr-hub#9 — re-syncs a user's role from their current Keycloak groups on every login, not just at account creation. Fixes mirk being stuck as `viewer` after being added to `arr-admin` (his account already existed, so the old first-login-only mapping never re-checked).

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh