### PR TITLE
feat(arr-hub): add group-membership protocol mapper

### DIFF
--- a/apps/downloads/arr-hub/app/keycloak-groups-mapper.yaml
+++ b/apps/downloads/arr-hub/app/keycloak-groups-mapper.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/keycloak.hostzero.com/keycloakprotocolmapper_v1beta1.json
+# Without this, Keycloak never includes a "groups" claim in the ID token, so
+# arr-hub's Keycloak group -> role mapping (GROUP_ROLE_MAP) never has anything
+# to match against and role changes never take effect on login.
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakProtocolMapper
+metadata:
+  name: arr-hub-groups
+spec:
+  name: groups
+  clientRef:
+    name: arr-hub
+  definition:
+    protocol: openid-connect
+    protocolMapper: oidc-group-membership-mapper
+    config:
+      claim.name: groups
+      full.path: "false"
+      id.token.claim: "true"
+      access.token.claim: "true"
+      userinfo.token.claim: "true"

--- a/apps/downloads/arr-hub/app/kustomization.yaml
+++ b/apps/downloads/arr-hub/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./external-secret.yaml
   - ./session-secret.yaml
   - ./keycloak-groups.yaml
+  - ./keycloak-groups-mapper.yaml


### PR DESCRIPTION
## Summary

Root cause of the `arr-admin` role change not taking effect: no `KeycloakProtocolMapper` resource exists anywhere in this cluster (checked \`kubectl get keycloakprotocolmappers -A\` — empty), and Keycloak doesn't include a \`groups\` claim in the ID token by default without one. So arr-hub's app-side group -> role mapping had nothing to match against, regardless of actual Keycloak group membership.

Adds an `oidc-group-membership-mapper` protocol mapper on arr-hub's `KeycloakClient`, claim name `groups`, unqualified names (`full.path: false`) matching what arr-hub's own group-matching code expects.

Verified with a local `kubectl kustomize` build.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh