### PR TITLE
feat(arr-dashboard): deploy Kha-kis/arr-dashboard as an arr-hub alternative

### DIFF
--- a/apps/downloads/arr-dashboard/app.ks.yaml
+++ b/apps/downloads/arr-dashboard/app.ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app arr-dashboard
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: downloads
+
+  path: ./apps/downloads/arr-dashboard/app
+  components:
+    - ../../../../components/volsync/
+    - ../../../../components/keycloak-client/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 512Mi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/downloads/arr-dashboard/app/helm-release.yaml
+++ b/apps/downloads/arr-dashboard/app/helm-release.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app arr-dashboard
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: arr-dashboard
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    controllers:
+      arr-dashboard:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: khak1s/arr-dashboard
+              tag: 2.24.1
+
+            env:
+              LOG_LEVEL: info
+              # Public origin arr-dashboard's own OIDC callback + WebAuthn
+              # relying-party logic needs, since this sits behind Envoy
+              # rather than being reached directly.
+              APP_URL: "https://arr-dashboard.home.mirceanton.com"
+
+            probes:
+              liveness: &probe
+                enabled: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 3000
+              readiness: *probe
+              startup:
+                enabled: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        # Rootless mode (see docs/AUTH docker section) - PUID/PGID are
+        # ignored when the container is run as a fixed non-root user.
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+
+    route:
+      home:
+        hostnames: ["arr-dashboard.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      config:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /config
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/apps/downloads/arr-dashboard/app/kustomization.yaml
+++ b/apps/downloads/arr-dashboard/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml

--- a/apps/downloads/arr-dashboard/app/oci-repository.yaml
+++ b/apps/downloads/arr-dashboard/app/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: arr-dashboard
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/apps/downloads/arr-dashboard/kustomization.yaml
+++ b/apps/downloads/arr-dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/downloads/kustomization.yaml
+++ b/apps/downloads/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: downloads
 resources:
   - ./namespace.yaml
   - ./grafana-folder.yaml
+  - ./arr-dashboard
   - ./arr-hub
   - ./bazarr
   - ./flaresolverr


### PR DESCRIPTION
## Summary

Deploys https://github.com/Kha-kis/arr-dashboard for evaluation as a possible arr-hub replacement, per request.

- Own hostname (`arr-dashboard.home.mirceanton.com`), not taking over arr-hub's `downloads.home.mirceanton.com` yet — arr-hub keeps running until this is confirmed as a good fit.
- SQLite-backed (`/config/prod.db`) — the project's docs explicitly only support one instance/replica per database, so this matches upstream's own recommended default rather than adding a Postgres cluster for a single-container app.
- No `ExternalSecret` needed: unlike arr-hub, service instance URLs/API keys (Sonarr, Radarr, etc.) and the OIDC client id/secret are entered through arr-dashboard's own Settings UI after first login, not env vars.
- `KeycloakClient` provisioned via the same `keycloak-client` component as everything else, so the client id/secret are ready to paste into Settings once you get there.
- `APP_URL` set to the real external hostname — this project has a dedicated env var for the OIDC-callback/WebAuthn public origin, avoiding the whole class of bug we just fixed in arr-hub.

Verified the manifests with a local `kubectl kustomize` build (volsync + keycloak-client components merged, same technique used for prior PRs).

## Next steps (manual, after this deploys)

1. Open `https://arr-dashboard.home.mirceanton.com`, create the initial admin account.
2. Add Sonarr/Radarr/Lidarr/Prowlarr/Bazarr instances in Settings.
3. Optionally configure OIDC in Settings → Auth using the `arr-dashboard-oidc-secret` client id/secret.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh