### PR TITLE
feat(container): update ghcr.io/mirceanton/arr-hub ( v0.3.0 → v0.4.0 )

### DIFF
--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/arr-hub
-              tag: v0.3.0
+              tag: v0.4.0
 
             env:
               DATABASE_URL: file:/data/app.db


### PR DESCRIPTION
Picks up mirceanton/arr-hub#10 — granular Sonarr season requests, admin-configurable auto-approval (global + per-user), request deletion (own + admin any), a new Calendar page with request history, real poster art in search results, and hidden service versions for non-admins.

Includes new DB columns/table (requests.selection, users.auto_approve, app_settings) — migrations run automatically at container start via docker-entrypoint.sh.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh