### PR TITLE
feat(keycloak): add realm-wide groups protocol mapper

### DIFF
--- a/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
+++ b/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
@@ -29,3 +29,33 @@ spec:
   realmName: Homelab
   definition:
     realm: Homelab
+
+    # NOTE: `definition` is a verbatim passthrough to Keycloak's RealmRepresentation
+    # API - the operator doesn't merge/append into list fields, it replaces them.
+    # `defaultDefaultClientScopes` below is therefore the FULL desired list, not
+    # an addition to it: it must include Keycloak's built-in OIDC defaults
+    # (profile, email, roles, web-origins, acr) or every client in the realm
+    # silently loses them. Double-check these against Client Scopes > Default
+    # in the admin console before merging, in case anything else was added
+    # there manually since.
+    clientScopes:
+      - name: groups
+        protocol: openid-connect
+        protocolMappers:
+          - name: groups
+            protocol: openid-connect
+            protocolMapper: oidc-group-membership-mapper
+            config:
+              full.path: "false"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              claim.name: groups
+
+    defaultDefaultClientScopes:
+      - profile
+      - email
+      - roles
+      - web-origins
+      - acr
+      - groups

--- a/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
+++ b/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
@@ -30,11 +30,6 @@ spec:
   definition:
     realm: Homelab
 
-    # Defines the "groups" client scope + mapper only - it is NOT added to
-    # defaultDefaultClientScopes here. Assignment happens per-client instead,
-    # via each KeycloakClient's own defaultClientScopes (see the keycloak-client
-    # component), since that applies to existing clients too and doesn't
-    # require keeping this realm-wide list in sync with it.
     clientScopes:
       - name: groups
         protocol: openid-connect

--- a/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
+++ b/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
@@ -30,14 +30,11 @@ spec:
   definition:
     realm: Homelab
 
-    # NOTE: `definition` is a verbatim passthrough to Keycloak's RealmRepresentation
-    # API - the operator doesn't merge/append into list fields, it replaces them.
-    # `defaultDefaultClientScopes` below is therefore the FULL desired list, not
-    # an addition to it: it must include Keycloak's built-in OIDC defaults
-    # (profile, email, roles, web-origins, acr) or every client in the realm
-    # silently loses them. Double-check these against Client Scopes > Default
-    # in the admin console before merging, in case anything else was added
-    # there manually since.
+    # Defines the "groups" client scope + mapper only - it is NOT added to
+    # defaultDefaultClientScopes here. Assignment happens per-client instead,
+    # via each KeycloakClient's own defaultClientScopes (see the keycloak-client
+    # component), since that applies to existing clients too and doesn't
+    # require keeping this realm-wide list in sync with it.
     clientScopes:
       - name: groups
         protocol: openid-connect
@@ -51,11 +48,3 @@ spec:
               access.token.claim: "true"
               userinfo.token.claim: "true"
               claim.name: groups
-
-    defaultDefaultClientScopes:
-      - profile
-      - email
-      - roles
-      - web-origins
-      - acr
-      - groups

--- a/components/keycloak-client/keycloak-client.yaml
+++ b/components/keycloak-client/keycloak-client.yaml
@@ -29,3 +29,15 @@ spec:
       - ${KEYCLOAK_CLIENT_REDIRECT_URL:-"https://${APP}.home.mirceanton.com/*"}
     webOrigins:
       - ${KEYCLOAK_CLIENT_WEB_ORIGIN:-"https://${APP}.home.mirceanton.com"}
+
+    # NOTE: full replace, not an addition - see the realm's defaultDefaultClientScopes
+    # comment for why. Realm-level defaults only apply to clients created after
+    # they're set, so this is what actually gets every EXISTING client (not just
+    # new ones) the groups claim on the next reconcile.
+    defaultClientScopes:
+      - profile
+      - email
+      - roles
+      - web-origins
+      - acr
+      - groups

--- a/components/keycloak-client/keycloak-client.yaml
+++ b/components/keycloak-client/keycloak-client.yaml
@@ -29,15 +29,4 @@ spec:
       - ${KEYCLOAK_CLIENT_REDIRECT_URL:-"https://${APP}.home.mirceanton.com/*"}
     webOrigins:
       - ${KEYCLOAK_CLIENT_WEB_ORIGIN:-"https://${APP}.home.mirceanton.com"}
-
-    # NOTE: full replace, not an addition - see the realm's defaultDefaultClientScopes
-    # comment for why. Realm-level defaults only apply to clients created after
-    # they're set, so this is what actually gets every EXISTING client (not just
-    # new ones) the groups claim on the next reconcile.
-    defaultClientScopes:
-      - profile
-      - email
-      - roles
-      - web-origins
-      - acr
-      - groups
+    defaultClientScopes: ${KEYCLOAK_CLIENT_DEFAULT_SCOPES:-["profile", "email", "roles", "web-origins", "acr", "groups"]}


### PR DESCRIPTION
## Summary
- Define a `groups` client scope on the `Homelab` realm with an `oidc-group-membership-mapper`, so any client can get a `groups` claim in its tokens.
- Set that scope on every `KeycloakClient`'s own `defaultClientScopes` in the shared component, since that's what actually applies it — including to clients that already exist (arr-hub, modelhub, immich, etc.), not just ones created from now on.
- Made the client-level scope list configurable via a new `KEYCLOAK_CLIENT_DEFAULT_SCOPES` Flux postBuild variable, defaulting to the current list (`profile, email, roles, web-origins, acr, groups`). A client that ever needs a different set can override it without forking the component.

The realm only *defines* the scope + mapper; it's deliberately not added to the realm's `defaultDefaultClientScopes`. That setting only auto-assigns to brand-new clients anyway, so keeping it would just be a second list to keep in sync with the per-client one for no real benefit, given every client here goes through the shared component.
