### PR TITLE
fix(keycloak): create groups client scope via dedicated CRD

### DIFF
--- a/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
+++ b/apps/security-system/keycloak-operator/config/cluster-keycloak-instance.yaml
@@ -29,17 +29,3 @@ spec:
   realmName: Homelab
   definition:
     realm: Homelab
-
-    clientScopes:
-      - name: groups
-        protocol: openid-connect
-        protocolMappers:
-          - name: groups
-            protocol: openid-connect
-            protocolMapper: oidc-group-membership-mapper
-            config:
-              full.path: "false"
-              id.token.claim: "true"
-              access.token.claim: "true"
-              userinfo.token.claim: "true"
-              claim.name: groups

--- a/apps/security-system/keycloak-operator/config/keycloak-groups-scope.yaml
+++ b/apps/security-system/keycloak-operator/config/keycloak-groups-scope.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/keycloak.hostzero.com/keycloakclientscope_v1beta1.json
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakClientScope
+metadata:
+  name: groups
+spec:
+  name: groups
+  clusterRealmRef:
+    name: homelab
+  definition:
+    protocol: openid-connect
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/keycloak.hostzero.com/keycloakprotocolmapper_v1beta1.json
+apiVersion: keycloak.hostzero.com/v1beta1
+kind: KeycloakProtocolMapper
+metadata:
+  name: groups
+spec:
+  name: groups
+  clientScopeRef:
+    name: groups
+  definition:
+    protocol: openid-connect
+    protocolMapper: oidc-group-membership-mapper
+    config:
+      full.path: "false"
+      id.token.claim: "true"
+      access.token.claim: "true"
+      userinfo.token.claim: "true"
+      claim.name: groups

--- a/apps/security-system/keycloak-operator/config/kustomization.yaml
+++ b/apps/security-system/keycloak-operator/config/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 
 resources:
   - ./cluster-keycloak-instance.yaml
+  - ./keycloak-groups-scope.yaml


### PR DESCRIPTION
## Summary
#1139 (merged) defined the `groups` client scope and its `oidc-group-membership-mapper` inside `ClusterKeycloakRealm.spec.definition.clientScopes`, on the assumption that the operator's realm sync would create it in Keycloak. It doesn't.

## Root cause
Keycloak's realm *update* endpoint (`PUT /admin/realms/{realm}`) silently ignores nested `clientScopes` — that field is only processed on realm *import* (creating a brand-new realm from a full export), not on updating an existing one. The operator logs "realm updated successfully" with no error, but Keycloak never actually creates the scope. Every client with `groups` in `defaultClientScopes` (added in #1139's other half) now fails to reconcile:

```
Failed to sync client scopes: failed to sync default client scopes:
default scope "groups" does not exist in realm "Homelab"
```

Confirmed live: `arr-hub`, `headlamp`, `bazarr`, `sonarr`, `litellm`, `renovate-operator`, `home-assistant`, `bambuddy`, `bookorbit`, and `paperless` are all currently in `ScopeSyncFailed` status because of this.

## Fix
Create the scope via the operator's dedicated `KeycloakClientScope` CRD (which calls Keycloak's `POST /client-scopes` endpoint directly, not the realm-update passthrough), and attach the mapper via `KeycloakProtocolMapper`'s `clientScopeRef`. Both are real, separate CRDs this operator ships specifically for this — confirmed against the live CRD schemas.

## Test plan
- [ ] After merge/reconcile, confirm `KeycloakClientScope/groups` and `KeycloakProtocolMapper/groups` in `security-system` both report `Ready`
- [ ] Confirm the clients currently in `ScopeSyncFailed` recover to `Ready` on their next reconcile
- [ ] Confirm a token from one of them actually includes the `groups` claim