### PR TITLE
feat(container): update ghcr.io/mirceanton/arr-hub ( v0.5.0 → v0.6.0 )

### DIFF
--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/arr-hub
-              tag: v0.5.0
+              tag: v0.6.0
 
             env:
               DATABASE_URL: file:/data/app.db


### PR DESCRIPTION
Picks up mirceanton/arr-hub#12 — admin-only break-glass proxy to each configured service's own web UI, embedded via iframe on a new /services/<id> page.

Note: to actually use it for a given service, that service's own "URL Base" setting needs to be set to /api/proxy/<service> so its asset/API links resolve through the proxy.

https://claude.ai/code/session_01JEboiW2qKmnMRZR1CuKgCh