### PR TITLE
feat(arr-hub): wire TMDB/Last.fm recommendation keys, bump to v0.7.0

### DIFF
--- a/apps/downloads/arr-hub/app/external-secret.yaml
+++ b/apps/downloads/arr-hub/app/external-secret.yaml
@@ -36,3 +36,11 @@ spec:
       remoteRef:
         key: Prowlarr API Key
         property: password
+    - secretKey: TMDB_API_KEY
+      remoteRef:
+        key: TMDB API Key
+        property: password
+    - secretKey: LASTFM_API_KEY
+      remoteRef:
+        key: LastFM API Key
+        property: password

--- a/apps/downloads/arr-hub/app/helm-release.yaml
+++ b/apps/downloads/arr-hub/app/helm-release.yaml
@@ -22,7 +22,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/arr-hub
-              tag: v0.6.0
+              tag: v0.7.0
 
             env:
               DATABASE_URL: file:/data/app.db
@@ -84,6 +84,20 @@ spec:
                   secretKeyRef:
                     name: arr-hub-secret
                     key: PROWLARR_API_KEY
+
+              # Power the "More like this" recommendations panel — TMDB for
+              # movies/shows, Last.fm for artists. Both are optional in the
+              # app itself, but wired here so the feature is live.
+              TMDB_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: TMDB_API_KEY
+              LASTFM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: arr-hub-secret
+                    key: LASTFM_API_KEY
 
             probes:
               liveness:


### PR DESCRIPTION
## Summary
- Bump `ghcr.io/mirceanton/arr-hub` to v0.7.0 (library browsing + recommendations + reliable progress matching)
- Add `TMDB_API_KEY` / `LASTFM_API_KEY` to arr-hub's ExternalSecret, sourced from the 1Password items "TMDB API Key" and "LastFM API Key" (`password` field), matching the existing per-service API key pattern
- Wire both into the HelmRelease env via `secretKeyRef`

## Test plan
- [x] `mise exec -- task lint:check` (prettier + actionlint)
- [ ] Flux reconciles the new HelmRelease revision and pod restarts (via Reloader) picking up the new secret keys