### PR TITLE
feat(downloads): add bindery for audiobook/ebook management

### DIFF
--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -143,6 +143,12 @@ services:
         target: "_blank"
         logo: "assets/icons/webp/shelfmark.webp"
 
+      - name: "Bindery"
+        subtitle: "Audiobooks & eBooks"
+        url: "https://bindery.home.mirceanton.com"
+        target: "_blank"
+        icon: "fas fa-book-open"
+
       - name: "Bazarr"
         subtitle: "Subtitles"
         url: "https://bazarr.home.mirceanton.com"

--- a/apps/downloads/bindery/app.ks.yaml
+++ b/apps/downloads/bindery/app.ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bindery
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: downloads
+
+  path: ./apps/downloads/bindery/app
+  components:
+    - ../../../../components/volsync/
+    - ../../../../components/nfs-scaler/
+    - ../../../../components/oidc/
+    - ../../../../components/keycloak-client/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 4Gi
+      VOLSYNC_PUID: "568"
+      VOLSYNC_PGID: "568"
+
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: keda
+      namespace: kube-system
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/downloads/bindery/app/api-key-pushsecret.yaml
+++ b/apps/downloads/bindery/app/api-key-pushsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: bindery-api-key-pushsecret
+spec:
+  refreshInterval: 1h
+  deletionPolicy: Delete
+  updatePolicy: Replace
+
+  secretStoreRefs:
+    - name: onepassword
+      kind: ClusterSecretStore
+
+  selector:
+    secret:
+      name: bindery-secret
+
+  data:
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: Bindery API Key
+          property: password

--- a/apps/downloads/bindery/app/api-key-secret.yaml
+++ b/apps/downloads/bindery/app/api-key-secret.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: bindery-secret
+spec:
+  length: 32
+  digits: 10
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name bindery-secret
+spec:
+  refreshInterval: "0"
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: bindery-secret

--- a/apps/downloads/bindery/app/helm-release.yaml
+++ b/apps/downloads/bindery/app/helm-release.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bindery
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: bindery
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      bindery:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 568
+            runAsNonRoot: true
+            runAsUser: 568
+        containers:
+          app:
+            image:
+              repository: ghcr.io/vavallee/bindery
+              tag: 1.34.0@sha256:91f9fcfca1116d5e44090282063fc9c2a6c7283752e1a62df2c5953af4c12faf
+            env:
+              BINDERY_PORT: &port 8787
+              BINDERY_DATA_DIR: /config
+              BINDERY_DB_PATH: /config/bindery.db
+              BINDERY_LOG_LEVEL: info
+              BINDERY_LIBRARY_DIR: /books
+              BINDERY_DOWNLOAD_DIR: /downloads
+              BINDERY_PUID: "568"
+              BINDERY_PGID: "568"
+              # Bindery's own auth (local account / OIDC / proxy) is separate
+              # from the gateway-level OIDC below; this only seeds the initial
+              # API key used by its arr-compatible /api endpoints.
+              BINDERY_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: bindery-secret
+                    key: password
+              # Envoy Gateway is the only ingress path for this pod, so trusting
+              # the whole pod CIDR here is safe — it's how the proxy's own pod IP
+              # reaches this container. Needed for correct X-Forwarded-Proto
+              # handling (cookie Secure flag, OPDS feed URLs).
+              BINDERY_TRUSTED_PROXY: 10.244.0.0/24
+              # OpenLibrary rate-limits by User-Agent; without a distinct contact
+              # the whole Bindery fleet shares one default UA bucket.
+              BINDERY_CONTACT: https://mirceanton.com
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      home:
+        hostnames: ["bindery.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      config:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /config
+      # Same NFS-backed library BookOrbit reads from. Bindery places ebooks
+      # and audiobooks side by side in one folder here (BINDERY_AUDIOBOOK_DIR
+      # left unset falls back to this path) — BookOrbit picks up whatever
+      # lands there without any extra wiring.
+      books:
+        type: nfs
+        server: nas.stor.h.mirceanton.com
+        path: /mnt/tank/Media/Books
+        globalMounts:
+          - path: /books
+      downloads:
+        type: nfs
+        server: nas.stor.h.mirceanton.com
+        path: /mnt/scratch/Torrent_Downloads
+        globalMounts:
+          - path: /downloads
+      tmp:
+        type: emptyDir

--- a/apps/downloads/bindery/app/kustomization.yaml
+++ b/apps/downloads/bindery/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./api-key-secret.yaml
+  - ./api-key-pushsecret.yaml

--- a/apps/downloads/bindery/app/oci-repository.yaml
+++ b/apps/downloads/bindery/app/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bindery
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/apps/downloads/bindery/kustomization.yaml
+++ b/apps/downloads/bindery/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/downloads/kustomization.yaml
+++ b/apps/downloads/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./namespace.yaml
   - ./grafana-folder.yaml
   - ./bazarr
+  - ./bindery
   - ./flaresolverr
   - ./lidarr
   - ./prowlarr


### PR DESCRIPTION
## Summary
Replaces the Chaptarr attempt (#1152, closed) with [Bindery](https://github.com/vavallee/bindery) — a Readarr replacement built to avoid the exact problem Chaptarr hit: its default metadata pipeline leads with **OpenLibrary** (documented public API, no scraping/aggregation-flood) instead of pulling every provider's edition of every book, with Google Books/Hardcover/DNB/Audnex/Audible as opt-in enrichers behind it.

- Deployed via the app-template pattern (matching every other app in `downloads`) rather than Bindery's own bundled Helm chart — that chart isn't published anywhere (no OCI/Helm-repo artifact, source-only in-repo), which would've broken from this repo's OCIRepository-everywhere convention for a one-off app.
- Mounts the same `Media/Books` NFS share BookOrbit reads its library from (`/books`) — Bindery places ebooks and audiobooks side by side in one folder there by default (`BINDERY_AUDIOBOOK_DIR` unset falls back to the library dir), and the same `Torrent_Downloads` share qBittorrent writes to (`/downloads`). Same "just share a media folder" relationship Sonarr/Radarr already have with Jellyfin — no git-managed API wiring between apps in this repo.
- API key (`BINDERY_API_KEY`, a seed-only bootstrap value per Bindery's own docs) is generated in-cluster via an external-secrets `Password` generator and pushed to a new "Bindery API Key" 1Password item via `PushSecret` — same pattern as `hermano`/`arr-hub`/the corrected Chaptarr setup, no manual 1Password step needed.
- `BINDERY_TRUSTED_PROXY` set to the cluster pod CIDR (`10.244.0.0/24`) so `X-Forwarded-Proto`/`Host` from Envoy Gateway are honored correctly (cookie `Secure` flag, OPDS feed URLs) — Bindery's docs call this out as needed behind any reverse proxy, not just for proxy-auth mode.
- `BINDERY_CONTACT` set to `https://mirceanton.com` — Bindery's docs flag that OpenLibrary rate-limits by User-Agent and the whole fleet of default installs shares one bucket; a distinct contact avoids future 403s.
- No Prometheus exporter — Bindery doesn't expose `/metrics`.

## Validation
Rendered with `flux build kustomization --dry-run` and applied directly to the live cluster before merge:
- OCIRepository resolves the chart, KeycloakClient goes Ready, PVC (4Gi, matching Bindery's own chart's suggested default) binds
- Pod reaches `1/1 Running` in seconds (single Go binary vs. Chaptarr's .NET startup) — 82 SQLite migrations applied cleanly, log confirms `"seeded API key from BINDERY_API_KEY env var"` and `"metadata primary provider":"openlibrary"`
- `GET /api/v1/health` → `200`; `X-Api-Key` auth confirmed working against `/api/v1/system/status`
- All three real mounts verified via a `kubectl debug` copy of the pod: `/config` (568:568, correct ownership), `/books` (same NFS export BookOrbit/Shelfmark use — sees the existing 36-book library), `/downloads` (same export qBittorrent writes to)
- `PushSecret` synced successfully — "Bindery API Key" 1Password item created automatically

## Notes / manual follow-ups
- First boot goes through Bindery's own first-run admin-account UI (it has native local/OIDC/proxy auth, DB-backed, no bootstrap env var to pre-select a mode) — same pattern as several other apps in this cluster with their own first-run wizards (BookOrbit, Jellyfin, Immich). If pure gateway-SSO is wanted, switch Bindery's own auth mode to Disabled/Proxy in Settings after first login.
- Add qBittorrent as a download client and Prowlarr/indexers in Bindery's own Settings UI — same manual step as every other *arr-family app in this repo (no config-as-code layer wiring this across apps).
- You mentioned having a Hardcover API key — Bindery supports promoting Hardcover to primary metadata source or using it as enrichment (`Settings → Metadata`); happy to wire that in as a follow-up once you've had a chance to try the OpenLibrary-default experience.

## Test plan
- [x] `kustomize build apps/downloads/bindery/app` renders cleanly
- [x] `kustomize build apps/downloads` renders cleanly with the new app registered
- [x] `prettier --check` passes on all new/changed files
- [x] Applied live to the cluster: pod running, health check passing, mounts correct, API key generation + 1Password push working