### PR TITLE
feat(downloads): add Readarr (pennydreadful/bookshelf) with self-hosted metadata

### DIFF
--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -143,6 +143,12 @@ services:
         target: "_blank"
         logo: "assets/icons/webp/shelfmark.webp"
 
+      - name: "Bookshelf"
+        subtitle: "Audiobooks & eBooks"
+        url: "https://bookshelf.home.mirceanton.com"
+        target: "_blank"
+        icon: "fas fa-book"
+
       - name: "Bazarr"
         subtitle: "Subtitles"
         url: "https://bazarr.home.mirceanton.com"

--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -145,9 +145,9 @@ services:
 
       - name: "Bookshelf"
         subtitle: "Audiobooks & eBooks"
-        url: "https://bookshelf.home.mirceanton.com"
+        url: "https://readarr.home.mirceanton.com"
         target: "_blank"
-        icon: "fas fa-book"
+        logo: "assets/icons/webp/readarr.webp"
 
       - name: "Bazarr"
         subtitle: "Subtitles"

--- a/apps/default/homer/app/files/config.yaml
+++ b/apps/default/homer/app/files/config.yaml
@@ -143,7 +143,7 @@ services:
         target: "_blank"
         logo: "assets/icons/webp/shelfmark.webp"
 
-      - name: "Bookshelf"
+      - name: "Readarr"
         subtitle: "Audiobooks & eBooks"
         url: "https://readarr.home.mirceanton.com"
         target: "_blank"

--- a/apps/downloads/bookshelf/app.ks.yaml
+++ b/apps/downloads/bookshelf/app.ks.yaml
@@ -28,6 +28,11 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_PUID: "568"
       VOLSYNC_PGID: "568"
+      # Bookshelf is the canonical Readarr-family instance in this cluster —
+      # give it the readarr.* hostname instead of its own app name.
+      KEYCLOAK_CLIENT_HOME_URL: "https://readarr.home.mirceanton.com"
+      KEYCLOAK_CLIENT_REDIRECT_URLS: '["https://readarr.home.mirceanton.com/*"]'
+      KEYCLOAK_CLIENT_WEB_ORIGINS: '["https://readarr.home.mirceanton.com"]'
 
   dependsOn:
     - name: 1password-connect

--- a/apps/downloads/bookshelf/app.ks.yaml
+++ b/apps/downloads/bookshelf/app.ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app bookshelf
+  name: &app readarr
 spec:
   interval: 10m
   prune: true
@@ -28,11 +28,6 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_PUID: "568"
       VOLSYNC_PGID: "568"
-      # Bookshelf is the canonical Readarr-family instance in this cluster —
-      # give it the readarr.* hostname instead of its own app name.
-      KEYCLOAK_CLIENT_HOME_URL: "https://readarr.home.mirceanton.com"
-      KEYCLOAK_CLIENT_REDIRECT_URLS: '["https://readarr.home.mirceanton.com/*"]'
-      KEYCLOAK_CLIENT_WEB_ORIGINS: '["https://readarr.home.mirceanton.com"]'
 
   dependsOn:
     - name: 1password-connect

--- a/apps/downloads/bookshelf/app.ks.yaml
+++ b/apps/downloads/bookshelf/app.ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bookshelf
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: downloads
+
+  path: ./apps/downloads/bookshelf/app
+  components:
+    - ../../../../components/volsync/
+    - ../../../../components/nfs-scaler/
+    - ../../../../components/oidc/
+    - ../../../../components/keycloak-client/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_PUID: "568"
+      VOLSYNC_PGID: "568"
+
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: volsync
+      namespace: storage-system
+    - name: keda
+      namespace: kube-system
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/downloads/bookshelf/app/api-key-pushsecret.yaml
+++ b/apps/downloads/bookshelf/app/api-key-pushsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: bookshelf-api-key-pushsecret
+spec:
+  refreshInterval: 1h
+  deletionPolicy: Delete
+  updatePolicy: Replace
+
+  secretStoreRefs:
+    - name: onepassword
+      kind: ClusterSecretStore
+
+  selector:
+    secret:
+      name: bookshelf-secret
+
+  data:
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: Bookshelf API Key
+          property: password

--- a/apps/downloads/bookshelf/app/api-key-pushsecret.yaml
+++ b/apps/downloads/bookshelf/app/api-key-pushsecret.yaml
@@ -3,7 +3,7 @@
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
-  name: bookshelf-api-key-pushsecret
+  name: readarr-api-key-pushsecret
 spec:
   refreshInterval: 1h
   deletionPolicy: Delete
@@ -15,11 +15,11 @@ spec:
 
   selector:
     secret:
-      name: bookshelf-secret
+      name: readarr-secret
 
   data:
     - match:
         secretKey: password
         remoteRef:
-          remoteKey: Bookshelf API Key
+          remoteKey: Readarr API Key
           property: password

--- a/apps/downloads/bookshelf/app/api-key-secret.yaml
+++ b/apps/downloads/bookshelf/app/api-key-secret.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: bookshelf-secret
+spec:
+  length: 32
+  digits: 10
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name bookshelf-secret
+spec:
+  refreshInterval: "0"
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: bookshelf-secret

--- a/apps/downloads/bookshelf/app/api-key-secret.yaml
+++ b/apps/downloads/bookshelf/app/api-key-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: generators.external-secrets.io/v1alpha1
 kind: Password
 metadata:
-  name: bookshelf-secret
+  name: readarr-secret
 spec:
   length: 32
   digits: 10
@@ -15,7 +15,7 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &name bookshelf-secret
+  name: &name readarr-secret
 spec:
   refreshInterval: "0"
 
@@ -28,4 +28,4 @@ spec:
         generatorRef:
           apiVersion: generators.external-secrets.io/v1alpha1
           kind: Password
-          name: bookshelf-secret
+          name: readarr-secret

--- a/apps/downloads/bookshelf/app/helm-release.yaml
+++ b/apps/downloads/bookshelf/app/helm-release.yaml
@@ -3,12 +3,12 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: bookshelf
+  name: readarr
 spec:
   interval: 30m
   chartRef:
     kind: OCIRepository
-    name: bookshelf
+    name: readarr
 
   values:
     global:
@@ -18,7 +18,7 @@ spec:
       automountServiceAccountToken: false
 
     controllers:
-      bookshelf:
+      readarr:
         annotations:
           reloader.stakater.com/auto: "true"
         pod:
@@ -33,11 +33,6 @@ spec:
             image:
               repository: ghcr.io/pennydreadful/bookshelf
               tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359
-            # This image ships LSIO's s6-overlay init (root-owned chown steps,
-            # PUID/PGID handling) which doesn't work under a non-root pod
-            # securityContext. Bypass it entirely and exec the app binary
-            # directly, same as the one other known in-the-wild k8s deploy
-            # of this image (kondanta/homelab) does.
             command:
               - /usr/bin/catatonit
               - --
@@ -45,11 +40,11 @@ spec:
               - --nobrowser
               - --data=/config
             env:
-              READARR__APP__INSTANCENAME: Bookshelf
+              READARR__APP__INSTANCENAME: Readarr
               READARR__AUTH__APIKEY:
                 valueFrom:
                   secretKeyRef:
-                    name: bookshelf-secret
+                    name: readarr-secret
                     key: password
               READARR__AUTH__METHOD: External
               READARR__AUTH__REQUIRED: DisabledForLocalAddresses
@@ -103,8 +98,6 @@ spec:
         existingClaim: ${APP}
         globalMounts:
           - path: /config
-      # Same NFS-backed library BookOrbit/Chaptarr read from, mounted under
-      # both root-folder paths.
       books:
         type: nfs
         server: nas.stor.h.mirceanton.com
@@ -120,9 +113,6 @@ spec:
           - path: /downloads
       tmp:
         type: emptyDir
-      # The image bakes TMPDIR=/run/readarr-temp (used for e.g. scheduled
-      # backups) — mount it explicitly, otherwise it's read-only rootfs and
-      # the Backup task fails every cycle.
       run-temp:
         type: emptyDir
         globalMounts:

--- a/apps/downloads/bookshelf/app/helm-release.yaml
+++ b/apps/downloads/bookshelf/app/helm-release.yaml
@@ -120,3 +120,10 @@ spec:
           - path: /downloads
       tmp:
         type: emptyDir
+      # The image bakes TMPDIR=/run/readarr-temp (used for e.g. scheduled
+      # backups) — mount it explicitly, otherwise it's read-only rootfs and
+      # the Backup task fails every cycle.
+      run-temp:
+        type: emptyDir
+        globalMounts:
+          - path: /run/readarr-temp

--- a/apps/downloads/bookshelf/app/helm-release.yaml
+++ b/apps/downloads/bookshelf/app/helm-release.yaml
@@ -93,7 +93,7 @@ spec:
             port: *port
     route:
       home:
-        hostnames: ["bookshelf.home.mirceanton.com"]
+        hostnames: ["readarr.home.mirceanton.com"]
         parentRefs:
           - name: envoy-internal
             namespace: network-system

--- a/apps/downloads/bookshelf/app/helm-release.yaml
+++ b/apps/downloads/bookshelf/app/helm-release.yaml
@@ -1,0 +1,122 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bookshelf
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: bookshelf
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+
+    controllers:
+      bookshelf:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 568
+            runAsNonRoot: true
+            runAsUser: 568
+        containers:
+          app:
+            image:
+              repository: ghcr.io/pennydreadful/bookshelf
+              tag: hardcover-v0.4.20.129@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359
+            # This image ships LSIO's s6-overlay init (root-owned chown steps,
+            # PUID/PGID handling) which doesn't work under a non-root pod
+            # securityContext. Bypass it entirely and exec the app binary
+            # directly, same as the one other known in-the-wild k8s deploy
+            # of this image (kondanta/homelab) does.
+            command:
+              - /usr/bin/catatonit
+              - --
+              - /app/readarr/bin/Readarr
+              - --nobrowser
+              - --data=/config
+            env:
+              READARR__APP__INSTANCENAME: Bookshelf
+              READARR__AUTH__APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: bookshelf-secret
+                    key: password
+              READARR__AUTH__METHOD: External
+              READARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              READARR__LOG__LEVEL: info
+              READARR__SERVER__PORT: &port 8787
+              READARR__UPDATE__BRANCH: develop
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+
+            resources:
+              requests:
+                cpu: 20m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      home:
+        hostnames: ["bookshelf.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      config:
+        existingClaim: ${APP}
+        globalMounts:
+          - path: /config
+      # Same NFS-backed library BookOrbit/Chaptarr read from, mounted under
+      # both root-folder paths.
+      books:
+        type: nfs
+        server: nas.stor.h.mirceanton.com
+        path: /mnt/tank/Media/Books
+        globalMounts:
+          - path: /audiobooks
+          - path: /ebooks
+      downloads:
+        type: nfs
+        server: nas.stor.h.mirceanton.com
+        path: /mnt/scratch/Torrent_Downloads
+        globalMounts:
+          - path: /downloads
+      tmp:
+        type: emptyDir

--- a/apps/downloads/bookshelf/app/kustomization.yaml
+++ b/apps/downloads/bookshelf/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./api-key-secret.yaml
+  - ./api-key-pushsecret.yaml

--- a/apps/downloads/bookshelf/app/oci-repository.yaml
+++ b/apps/downloads/bookshelf/app/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bookshelf
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/apps/downloads/bookshelf/app/oci-repository.yaml
+++ b/apps/downloads/bookshelf/app/oci-repository.yaml
@@ -3,7 +3,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: bookshelf
+  name: readarr
 spec:
   interval: 15m
   layerSelector:

--- a/apps/downloads/bookshelf/kustomization.yaml
+++ b/apps/downloads/bookshelf/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml

--- a/apps/downloads/bookshelf/rreading-glasses.ks.yaml
+++ b/apps/downloads/bookshelf/rreading-glasses.ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: bookshelf-rreading-glasses
+  name: readarr-rreading-glasses
 spec:
   interval: 10m
   prune: true
@@ -23,7 +23,7 @@ spec:
       APP: rreading-glasses
 
   dependsOn:
-    - name: bookshelf
+    - name: readarr
     - name: 1password-connect
       namespace: security-system
     - name: cloudnative-pg-operator

--- a/apps/downloads/bookshelf/rreading-glasses.ks.yaml
+++ b/apps/downloads/bookshelf/rreading-glasses.ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: bookshelf-rreading-glasses
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  targetNamespace: downloads
+
+  path: ./apps/downloads/bookshelf/rreading-glasses
+  components:
+    - ../../../../components/cnpg/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: rreading-glasses
+
+  dependsOn:
+    - name: bookshelf
+    - name: 1password-connect
+      namespace: security-system
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: cloudnative-pg-plugins
+      namespace: database-system
+    - name: external-secrets-operator
+      namespace: security-system

--- a/apps/downloads/bookshelf/rreading-glasses/external-secret.yaml
+++ b/apps/downloads/bookshelf/rreading-glasses/external-secret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rreading-glasses-hardcover
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+
+  target:
+    name: rreading-glasses-hardcover
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        HARDCOVER_AUTH: "Bearer {{ .token }}"
+
+  data:
+    - secretKey: token
+      remoteRef:
+        key: Hardcover API Key
+        property: password

--- a/apps/downloads/bookshelf/rreading-glasses/helm-release.yaml
+++ b/apps/downloads/bookshelf/rreading-glasses/helm-release.yaml
@@ -28,8 +28,6 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
-          # CNPG's Database CR creates the DB/owner async — block until the
-          # app's own database is actually reachable, same pattern as atuin.
           wait-for-postgres:
             image:
               repository: ghcr.io/wait4x/wait4x
@@ -99,7 +97,6 @@ spec:
               capabilities:
                 drop: ["ALL"]
 
-    # Internal-only metadata bridge for Bookshelf — no ingress route, no OIDC.
     service:
       app:
         ports:

--- a/apps/downloads/bookshelf/rreading-glasses/helm-release.yaml
+++ b/apps/downloads/bookshelf/rreading-glasses/helm-release.yaml
@@ -1,0 +1,107 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rreading-glasses
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: rreading-glasses
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 568
+        runAsNonRoot: true
+        runAsUser: 568
+
+    controllers:
+      rreading-glasses:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # CNPG's Database CR creates the DB/owner async — block until the
+          # app's own database is actually reachable, same pattern as atuin.
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.7.1
+            args: ["postgresql", "$(DB_URL)"]
+            env:
+              DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: uri
+        containers:
+          app:
+            image:
+              repository: docker.io/blampe/rreading-glasses
+              tag: hardcover@sha256:6db4551f77c038516b55dab689f3b473c2c5fdf8f13580b91a8ba39360c3d107
+            command: ["/main", "serve"]
+            args: ["--verbose"]
+            env:
+              POSTGRES_HOST:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: host
+              POSTGRES_DATABASE:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: dbname
+              POSTGRES_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: username
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: password
+              HARDCOVER_AUTH:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-hardcover
+                    key: HARDCOVER_AUTH
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8788
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    # Internal-only metadata bridge for Bookshelf — no ingress route, no OIDC.
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/apps/downloads/bookshelf/rreading-glasses/kustomization.yaml
+++ b/apps/downloads/bookshelf/rreading-glasses/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./app.ks.yaml
-  - ./rreading-glasses.ks.yaml
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/downloads/bookshelf/rreading-glasses/oci-repository.yaml
+++ b/apps/downloads/bookshelf/rreading-glasses/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rreading-glasses
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/apps/downloads/kustomization.yaml
+++ b/apps/downloads/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./namespace.yaml
   - ./grafana-folder.yaml
   - ./bazarr
+  - ./bookshelf
   - ./flaresolverr
   - ./lidarr
   - ./prowlarr

--- a/components/oidc/security-policy.yaml
+++ b/components/oidc/security-policy.yaml
@@ -55,5 +55,5 @@ spec:
     clientID: ${OIDC_CLIENT_ID:-"${APP}"}
     clientSecret:
       name: "${APP}-oidc-secret"
-    redirectURL: ${KEYCLOAK_CLIENT_HOME_URL:-https://${APP}.home.mirceanton.com}/oauth2/callback
+    redirectURL: "https://${APP}.home.mirceanton.com/oauth2/callback"
     logoutPath: "/oauth2/logout"

--- a/components/oidc/security-policy.yaml
+++ b/components/oidc/security-policy.yaml
@@ -55,5 +55,5 @@ spec:
     clientID: ${OIDC_CLIENT_ID:-"${APP}"}
     clientSecret:
       name: "${APP}-oidc-secret"
-    redirectURL: "https://${APP}.home.mirceanton.com/oauth2/callback"
+    redirectURL: ${KEYCLOAK_CLIENT_HOME_URL:-https://${APP}.home.mirceanton.com}/oauth2/callback
     logoutPath: "/oauth2/logout"


### PR DESCRIPTION
## Summary
- Deploys Readarr (`ghcr.io/pennydreadful/bookshelf`, a maintained community revival of the original Readarr with working Hardcover metadata) into the `downloads` namespace, following the app-template pattern (OIDC, Keycloak client, volsync-backed config PVC, NFS-scaler). Git directory stays `apps/downloads/bookshelf/` (matches the upstream project name), but every deployed k8s resource is named `readarr` since that's the role it fills in this cluster — HelmRelease, PVC, secrets, KeycloakClient, route, all consistently `readarr-*`, at `readarr.home.mirceanton.com` with the real `readarr.webp` dashboard icon.
- **Chaptarr has been removed** (#1155 closed unmerged) — evaluated both live side by side, Chaptarr's actual behavior (metadata catalog flooding, buggy UI/stats per independent third-party benchmarking) came out worse. Readarr is now the sole Readarr-family app in this cluster.
- Self-hosts [rreading-glasses](https://github.com/blampe/rreading-glasses) — the actual open-source project behind the public `hardcover.bookinfo.pro` metadata bridge this fork's `hardcover` tag points at by default. That shared free service has no per-user quota and rate-limited us within minutes of normal RSS sync activity; self-hosting with our own Hardcover API key gives it a dedicated quota. Nested at `apps/downloads/bookshelf/rreading-glasses/` as a dependent sub-Kustomization (`readarr-rreading-glasses`, `dependsOn: readarr`) — same pattern `sonarr/exporter` uses, not a standalone top-level app. Internal-only (no route, no OIDC), backed by a CNPG-provisioned Postgres even though its actual storage need is a single self-migrated cache table — kept for consistency and free barman-cloud backups.
- Mounts the same `Torrent_Downloads` NFS share (`/downloads`) and `Media/Books` NFS share (`/audiobooks`, `/ebooks`) as BookOrbit.
- API key generated **in-cluster** via external-secrets `Password` generator + `PushSecret` to a "Readarr API Key" 1Password item. rreading-glasses' Hardcover API key pulled from a pre-existing personal "Hardcover API Key" 1Password item via a standard pull-based `ExternalSecret`.

## Deployment notes
This image ships LinuxServer.io's s6-overlay init (root-owned chown steps, PUID/PGID handling) which isn't compatible with this repo's non-root pod securityContext convention. The container `command` bypasses s6 entirely and execs the Readarr binary directly via `catatonit` (already present in the image) — the same approach the one other known public k8s deployment of this image (`kondanta/homelab`) uses. A separate fix mounts `/run/readarr-temp` (the image's baked-in `TMPDIR`, used by the scheduled Backup task) since only `/tmp` was covered initially.

Per upstream's README: *"only one type of a given book is supported. If you want both an audiobook and ebook of a given book you will need multiple instances."* Both `/audiobooks` and `/ebooks` root folder paths are mounted for flexibility, but this is a known limitation if dual-format management of the same title matters.

## Notes / manual follow-ups
No config-as-code layer in this repo for *arr apps — these are manual UI steps after deploy:
- In Prowlarr's UI, add Readarr under Settings → Apps (done).
- In its own UI, add qBittorrent as a download client (done), register root folders (done).
- Point it at the self-hosted metadata bridge: `Settings → Development` (hidden page) → `Metadata Provider Source` → `http://rreading-glasses.downloads.svc.cluster.local:8788` (done, validated live).
- No Prometheus exporter — `exportarr` doesn't support Readarr-family apps.

## Test plan
- [x] `kustomize build`/`flux build --dry-run` render cleanly for both `bookshelf/app` and `bookshelf/rreading-glasses`, fully consistent `readarr-*` naming, no leftover `bookshelf` references
- [x] Applied live under the original `bookshelf` name first, validated: pod running, health check passing, mounts correct, secret generation + 1Password push working
- [x] rreading-glasses: CNPG cluster healthy, pod running, `/search` returns real Hardcover-backed results authenticated with our own key; Readarr successfully switched to it and could look up authors again (previously blocked by the shared service's rate limit)
- [x] Library backlog (30 books) imported and organized into `{Author}/{Book Title}/` via the new metadata source
- [x] Renamed live from `bookshelf` to `readarr`: scaled old deployment to 0, applied new `readarr`-named manifests, let the fresh VolSync-backed PVC bootstrap empty, migrated the config PVC contents across via a temporary pod (verified via direct SQLite inspection: 30 authors/82 books/1 root folder present), restarted to pick up the migrated DB, deleted all old `bookshelf`-named resources
- [x] Hostname cutover to `readarr.home.mirceanton.com` validated live — HTTPRoute, KeycloakClient (`Ready`, correct redirect URIs), and SecurityPolicy all confirmed serving the new hostname; full OIDC redirect flow traced end-to-end