### PR TITLE
feat(downloads): self-host rreading-glasses for Bookshelf metadata

### DIFF
--- a/apps/downloads/kustomization.yaml
+++ b/apps/downloads/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./qbittorrent
   - ./qui
   - ./radarr
+  - ./rreading-glasses
   - ./shelfmark
   - ./sonarr
   - ./streamarr

--- a/apps/downloads/rreading-glasses/app.ks.yaml
+++ b/apps/downloads/rreading-glasses/app.ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rreading-glasses
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  targetNamespace: downloads
+
+  path: ./apps/downloads/rreading-glasses/app
+  components:
+    - ../../../../components/cnpg/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+
+  dependsOn:
+    - name: 1password-connect
+      namespace: security-system
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: cloudnative-pg-plugins
+      namespace: database-system
+    - name: external-secrets-operator
+      namespace: security-system

--- a/apps/downloads/rreading-glasses/app/external-secret.yaml
+++ b/apps/downloads/rreading-glasses/app/external-secret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rreading-glasses-hardcover
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+
+  target:
+    name: rreading-glasses-hardcover
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        HARDCOVER_AUTH: "Bearer {{ .token }}"
+
+  data:
+    - secretKey: token
+      remoteRef:
+        key: Hardcover API Key
+        property: password

--- a/apps/downloads/rreading-glasses/app/helm-release.yaml
+++ b/apps/downloads/rreading-glasses/app/helm-release.yaml
@@ -1,0 +1,107 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rreading-glasses
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: rreading-glasses
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 568
+        runAsNonRoot: true
+        runAsUser: 568
+
+    controllers:
+      rreading-glasses:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # CNPG's Database CR creates the DB/owner async — block until the
+          # app's own database is actually reachable, same pattern as atuin.
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.7.1
+            args: ["postgresql", "$(DB_URL)"]
+            env:
+              DB_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: uri
+        containers:
+          app:
+            image:
+              repository: docker.io/blampe/rreading-glasses
+              tag: hardcover@sha256:6db4551f77c038516b55dab689f3b473c2c5fdf8f13580b91a8ba39360c3d107
+            command: ["/main", "serve"]
+            args: ["--verbose"]
+            env:
+              POSTGRES_HOST:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: host
+              POSTGRES_DATABASE:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: dbname
+              POSTGRES_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: username
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-postgres-app
+                    key: password
+              HARDCOVER_AUTH:
+                valueFrom:
+                  secretKeyRef:
+                    name: rreading-glasses-hardcover
+                    key: HARDCOVER_AUTH
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8788
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    # Internal-only metadata bridge for Bookshelf — no ingress route, no OIDC.
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/apps/downloads/rreading-glasses/app/kustomization.yaml
+++ b/apps/downloads/rreading-glasses/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./external-secret.yaml

--- a/apps/downloads/rreading-glasses/app/oci-repository.yaml
+++ b/apps/downloads/rreading-glasses/app/oci-repository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rreading-glasses
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/apps/downloads/rreading-glasses/kustomization.yaml
+++ b/apps/downloads/rreading-glasses/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./app.ks.yaml


### PR DESCRIPTION
## Summary
- Bookshelf's `hardcover` tag points at `hardcover.bookinfo.pro`, a free shared community metadata bridge with no per-user auth/quota. Under normal RSS sync activity (120 releases/cycle from Prowlarr, several metadata queries per release) it rate-limited us within ~13 minutes and stayed down for hours.
- Self-hosts the actual open-source project behind that public service — [`blampe/rreading-glasses`](https://github.com/blampe/rreading-glasses) — with our own Hardcover API key, so Bookshelf gets a dedicated quota instead of sharing the saturated public one.
- Deployed to `apps/downloads/rreading-glasses/`, internal-only (no route, no OIDC — Bookshelf is the sole consumer via ClusterIP DNS at `rreading-glasses.downloads.svc.cluster.local:8788`).
- Backed by a CNPG-provisioned Postgres database (`components/cnpg/` component, same pattern as every other Postgres-backed app in this repo) — the app's own storage need is trivial (a single `cache` table it self-migrates), but this keeps it consistent with repo convention and gets barman-cloud backups for free.
- Hardcover API key pulled from the pre-existing "Hardcover API Key" 1Password item via a standard pull-based `ExternalSecret` (a personal, pre-existing key — not generated in-cluster).

## Validation
Applied live to the cluster before merge:
- CNPG cluster reached healthy state, seed job completed, app pod `1/1 Running`
- Hit `/search?q=Alex%20Hormozi` directly on the new service — got real results, authenticated against Hardcover (1.3s latency confirms a live upstream call, not a cache hit)
- Pointed Bookshelf at it via its hidden `Settings → Development` page (`PUT /api/v1/config/development`, `metadataSource` → our internal URL)
- Confirmed end-to-end: `GET /api/v1/author/lookup` through Bookshelf's own API now returns real Hardcover-backed results — the rate limit that was blocking the library import backlog is gone

## Notes
- Chaptarr can't be pointed at this — it uses a completely different, unrelated metadata backend, not rreading-glasses/bookinfo.pro.
- The hourly "Bookshelf library import retry" routine (`trig_01LtvNEf24Yyew4GWCFnwqBT`) should now succeed on its next run and complete the backlog import.

## Test plan
- [x] `kustomize build apps/downloads/rreading-glasses/app` renders cleanly
- [x] `kustomize build apps/downloads` renders cleanly with the new app registered
- [x] `flux build kustomization ... --dry-run` renders full composition (CNPG cluster/database/backup/seed-job components) cleanly
- [x] Applied live: CNPG healthy, pod running, `/search` returns real Hardcover data, Bookshelf successfully switched over and can look up authors again