### PR TITLE
fix(container): update ghcr.io/mirceanton/model-hub ( v0.12.0 → v0.13.0 )

### DIFF
--- a/apps/maker/modelhub/app/helm-release.yaml
+++ b/apps/maker/modelhub/app/helm-release.yaml
@@ -33,7 +33,7 @@ spec:
           app:
             image:
               repository: ghcr.io/mirceanton/model-hub
-              tag: v0.12.0
+              tag: v0.13.0
 
             env:
               PORT: &port 4000


### PR DESCRIPTION
Bumps the ModelHub image to v0.13.0, which includes:
- Stats and Admin folded into the user dropdown, with Stats as the default admin landing tab
- Primary nav (Models/Projects/Account) moved to a bottom tab bar on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)