### PR TITLE
fix(external-dns): migrate off external-dns.alpha.kubernetes.io annotation prefix

### DIFF
--- a/apps/games/minecraft/router/helm-release.yaml
+++ b/apps/games/minecraft/router/helm-release.yaml
@@ -55,4 +55,4 @@ spec:
         port: 25565
         annotations:
           lbipam.cilium.io/ips: 10.0.10.253
-          external-dns.alpha.kubernetes.io/hostname: badoink-mc.home.mirceanton.com
+          external-dns.kubernetes.io/hostname: badoink-mc.home.mirceanton.com

--- a/apps/network-system/envoy-gateway/app/admin/gateway.yaml
+++ b/apps/network-system/envoy-gateway/app/admin/gateway.yaml
@@ -5,7 +5,7 @@ kind: Gateway
 metadata:
   name: envoy-admin
   annotations:
-    external-dns.alpha.kubernetes.io/target: &loadbalancerIP 10.0.0.250
+    external-dns.kubernetes.io/target: &loadbalancerIP 10.0.0.250
 spec:
   gatewayClassName: envoy-admin
 

--- a/apps/network-system/envoy-gateway/app/home/gateway.yaml
+++ b/apps/network-system/envoy-gateway/app/home/gateway.yaml
@@ -5,7 +5,7 @@ kind: Gateway
 metadata:
   name: envoy-internal
   annotations:
-    external-dns.alpha.kubernetes.io/target: &loadbalancerIP 10.0.10.250
+    external-dns.kubernetes.io/target: &loadbalancerIP 10.0.10.250
 spec:
   gatewayClassName: envoy-internal
 

--- a/apps/network-system/envoy-gateway/app/https-redirect.http-route.yaml
+++ b/apps/network-system/envoy-gateway/app/https-redirect.http-route.yaml
@@ -5,7 +5,7 @@ kind: HTTPRoute
 metadata:
   name: https-redirect
   annotations:
-    external-dns.alpha.kubernetes.io/controller: none
+    external-dns.kubernetes.io/controller: none
 spec:
   # Apply this HTTPRoute to the internal Envoy Gateway
   parentRefs:

--- a/apps/youtube/davinci/app/patches/cnpg.yaml
+++ b/apps/youtube/davinci/app/patches/cnpg.yaml
@@ -14,6 +14,6 @@ spec:
               name: ${APP}-postgres-lb
               annotations:
                 lbipam.cilium.io/ips: 10.0.10.251
-                external-dns.alpha.kubernetes.io/hostname: davinci-pg.home.mirceanton.com
+                external-dns.kubernetes.io/hostname: davinci-pg.home.mirceanton.com
             spec:
               type: LoadBalancer


### PR DESCRIPTION
## Summary
- external-dns `v0.22.0` (chart `1.21.1 → 1.22.0`, [782d0e67](https://github.com/mirceanton/home-ops/commit/782d0e676e83c5ae3b45f3d86f66c6e5733da898)) changed the default `--annotation-prefix` from `external-dns.alpha.kubernetes.io/` to `external-dns.kubernetes.io/`, **with no fallback** ([upstream release notes](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.22.0): *"This change can delete all your DNS records"*)
- Confirmed via the live cluster (webhook provider's `/records`) that `davinci-pg.home.mirceanton.com` and `badoink-mc.home.mirceanton.com` were already deleted by external-dns as a result — these are the only two DNS records sourced from a bare `Service`'s `hostname` annotation rather than an Ingress/HTTPRoute's native host field, so they were the only ones with no other way to reach external-dns
- This PR migrates all 5 occurrences of the old `external-dns.alpha.kubernetes.io/*` annotation prefix in the repo to the new `external-dns.kubernetes.io/*` prefix:
  - `youtube/davinci-postgres-lb` — `hostname` (restores the deleted record)
  - `games/minecraft-router` — `hostname` (restores the deleted record)
  - `envoy-internal` / `envoy-admin` Gateways — `target` (currently masked by `status.addresses` matching, but was silently broken)
  - `network-system/https-redirect` HTTPRoute — `controller: none` opt-out (currently moot since the route has no hostnames, but was silently broken)
- No other resources in the cluster use annotation-derived hostnames (verified against all `HTTPRoute`/`Ingress`/`Service` objects), so nothing else is affected by this upstream change

## Test plan
- [x] `mise exec -- task lint:check` passes (prettier + actionlint)
- [ ] Flux reconciles the changed Kustomizations (`envoy-gateway`, `davinci`, `minecraft-router`) cleanly
- [ ] Confirm `davinci-pg.home.mirceanton.com` and `badoink-mc.home.mirceanton.com` reappear in the MikroTik router's DNS records after external-dns's next sync (~1m interval)
- [ ] Confirm `home.mirceanton.com` / `admin.mirceanton.com` gateway-fronted routes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)