### PR TITLE
feat(miniflux): deploy Miniflux RSS reader

### DIFF
--- a/apps/productivity/miniflux/app.ks.yaml
+++ b/apps/productivity/miniflux/app.ks.yaml
@@ -28,11 +28,11 @@ spec:
       KEYCLOAK_CLIENT_HOME_URL: "https://rss.home.mirceanton.com"
 
   dependsOn:
+    - name: 1password-connect
+      namespace: security-system
     - name: cloudnative-pg-operator
       namespace: database-system
     - name: cloudnative-pg-plugins
       namespace: database-system
-    - name: external-secrets-operator
-      namespace: security-system
     - name: keycloak-operator-config
       namespace: security-system

--- a/apps/productivity/miniflux/app.ks.yaml
+++ b/apps/productivity/miniflux/app.ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app miniflux
+spec:
+  interval: 10m
+  prune: true
+  wait: true
+  timeout: 15m
+  targetNamespace: productivity
+
+  path: ./apps/productivity/miniflux/app
+  components:
+    - ../../../../components/cnpg/
+    - ../../../../components/keycloak-client/
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  postBuild:
+    substitute:
+      APP: *app
+      KEYCLOAK_CLIENT_REDIRECT_URLS: '["https://rss.home.mirceanton.com/*"]'
+      KEYCLOAK_CLIENT_WEB_ORIGINS: '["https://rss.home.mirceanton.com"]'
+      KEYCLOAK_CLIENT_HOME_URL: "https://rss.home.mirceanton.com"
+
+  dependsOn:
+    - name: cloudnative-pg-operator
+      namespace: database-system
+    - name: cloudnative-pg-plugins
+      namespace: database-system
+    - name: external-secrets-operator
+      namespace: security-system
+    - name: keycloak-operator-config
+      namespace: security-system

--- a/apps/productivity/miniflux/app/admin-secret.yaml
+++ b/apps/productivity/miniflux/app/admin-secret.yaml
@@ -1,0 +1,35 @@
+---
+# Bootstrap credentials for the local admin account. Local login is only
+# needed once, to link this account to Keycloak under Settings > "Connect"
+# - after that DISABLE_LOCAL_AUTH can be flipped back to "1" and this admin
+# keeps working via OIDC. See helm-release.yaml for context.
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: miniflux-admin-secret
+spec:
+  length: 32
+  digits: 5
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name miniflux-admin-secret
+spec:
+  refreshInterval: "0"
+
+  target:
+    name: *name
+    creationPolicy: Owner
+
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: miniflux-admin-secret

--- a/apps/productivity/miniflux/app/helm-release.yaml
+++ b/apps/productivity/miniflux/app/helm-release.yaml
@@ -60,18 +60,19 @@ spec:
                   secretKeyRef: { name: miniflux-postgres-app, key: uri }
               RUN_MIGRATIONS: "1"
 
-              # Bootstrap-only local admin. Local login stays enabled just
-              # long enough to sign in once and link this account to
-              # Keycloak under Settings > "Connect" - after that, flip
-              # DISABLE_LOCAL_AUTH to "1" and redeploy. Miniflux has no way
-              # to mark an OIDC-created user as admin automatically, so this
-              # local account is the only path to admin rights.
+              # Local admin, bootstrapped once and linked to Keycloak under
+              # Settings > "Connect" - Miniflux has no way to mark an
+              # OIDC-created user as admin automatically, so this was the
+              # only path to admin rights. Kept only as a disaster-recovery
+              # fallback: Miniflux blocks local login entirely while
+              # DISABLE_LOCAL_AUTH is set, so flip it to "0" temporarily if
+              # OIDC login ever breaks.
               CREATE_ADMIN: "1"
               ADMIN_USERNAME: "admin"
               ADMIN_PASSWORD:
                 valueFrom:
                   secretKeyRef: { name: miniflux-admin-secret, key: password }
-              DISABLE_LOCAL_AUTH: "0"
+              DISABLE_LOCAL_AUTH: "1"
 
               OAUTH2_PROVIDER: "oidc"
               OAUTH2_OIDC_PROVIDER_NAME: "Keycloak"

--- a/apps/productivity/miniflux/app/helm-release.yaml
+++ b/apps/productivity/miniflux/app/helm-release.yaml
@@ -1,0 +1,150 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app miniflux
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: miniflux
+
+  values:
+    global:
+      createDefaultServiceAccount: false
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      miniflux:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          wait-for-postgres:
+            image:
+              repository: ghcr.io/wait4x/wait4x
+              tag: 3.7.1
+            args: ["postgresql", "$(DATABASE_URL)"]
+            env:
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef: { name: miniflux-postgres-app, key: uri }
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/miniflux/miniflux
+              tag: 2.3.3
+
+            env:
+              TZ: "Europe/Bucharest"
+              BASE_URL: "https://rss.home.mirceanton.com"
+
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef: { name: miniflux-postgres-app, key: uri }
+              RUN_MIGRATIONS: "1"
+
+              # Bootstrap-only local admin. Local login stays enabled just
+              # long enough to sign in once and link this account to
+              # Keycloak under Settings > "Connect" - after that, flip
+              # DISABLE_LOCAL_AUTH to "1" and redeploy. Miniflux has no way
+              # to mark an OIDC-created user as admin automatically, so this
+              # local account is the only path to admin rights.
+              CREATE_ADMIN: "1"
+              ADMIN_USERNAME: "admin"
+              ADMIN_PASSWORD:
+                valueFrom:
+                  secretKeyRef: { name: miniflux-admin-secret, key: password }
+              DISABLE_LOCAL_AUTH: "0"
+
+              OAUTH2_PROVIDER: "oidc"
+              OAUTH2_OIDC_PROVIDER_NAME: "Keycloak"
+              OAUTH2_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef: { name: miniflux-oidc-secret, key: client-id }
+              OAUTH2_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef: { name: miniflux-oidc-secret, key: client-secret }
+              # Discovery endpoint must NOT include the trailing
+              # /.well-known/openid-configuration - Miniflux appends it.
+              OAUTH2_OIDC_DISCOVERY_ENDPOINT: "https://keycloak.nas.svc.h.mirceanton.com/realms/Homelab"
+              OAUTH2_REDIRECT_URL: "https://rss.home.mirceanton.com/oauth2/oidc/callback"
+              OAUTH2_USER_CREATION: "1"
+
+              METRICS_COLLECTOR: "1"
+              METRICS_ALLOWED_NETWORKS: "10.244.0.0/16"
+
+            probes:
+              liveness:
+                enabled: true
+                type: HTTP
+                path: /liveness
+              readiness:
+                enabled: true
+                type: HTTP
+                path: /readiness
+              startup:
+                enabled: true
+                type: HTTP
+                path: /readiness
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      app:
+        controller: miniflux
+        ports:
+          http:
+            port: 8080
+
+    serviceMonitor:
+      app:
+        serviceName: miniflux
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+
+    route:
+      home:
+        hostnames: ["rss.home.mirceanton.com"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/apps/productivity/miniflux/app/kustomization.yaml
+++ b/apps/productivity/miniflux/app/kustomization.yaml
@@ -2,9 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: productivity
-
 resources:
-  - ./namespace.yaml
-  - ./affine
-  - ./miniflux
+  - ./oci-repository.yaml
+  - ./helm-release.yaml
+  - ./admin-secret.yaml

--- a/apps/productivity/miniflux/app/oci-repository.yaml
+++ b/apps/productivity/miniflux/app/oci-repository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.mirceanton.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: miniflux
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.1.0
+
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/apps/productivity/miniflux/kustomization.yaml
+++ b/apps/productivity/miniflux/kustomization.yaml
@@ -2,9 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: productivity
-
 resources:
-  - ./namespace.yaml
-  - ./affine
-  - ./miniflux
+  - ./app.ks.yaml


### PR DESCRIPTION
## Summary
- Deploy Miniflux (RSS feed reader) at `rss.home.mirceanton.com`, backed by Postgres via the `cnpg` component
- Native OIDC against Keycloak via the `keycloak-client` component (not the gateway-level `oidc` component) - Miniflux has its own built-in OAuth2/OIDC client
- Prometheus `ServiceMonitor` scraping `/metrics`
- Local form login disabled (`DISABLE_LOCAL_AUTH: "1"`) - the bootstrap admin account was signed in once and linked to Keycloak under Settings, then local auth was locked down. `CREATE_ADMIN`/`ADMIN_USERNAME`/`ADMIN_PASSWORD` stay in place as a disaster-recovery fallback (Miniflux has no way to auto-promote an OIDC-created user to admin, so this is the only path back in if OIDC ever breaks)

## Test plan
- [x] `task lint:check` passes
- [x] `flux build kustomization` renders cleanly with all substitutions resolved
- [x] Live-applied to the cluster: Postgres cluster healthy, KeycloakClient `Ready`, pod running and passing health checks
- [x] Verified OIDC-only login end-to-end (local login blocked, OIDC redirect to Keycloak correct, linked admin account logs in via OIDC)
- [x] `/metrics` and `/healthcheck` endpoints responding