### PR TITLE
fix(paperless): use human-readable filename format

### DIFF
--- a/apps/media/paperless/app/helm-release.yaml
+++ b/apps/media/paperless/app/helm-release.yaml
@@ -74,6 +74,9 @@ spec:
               PAPERLESS_EXPORT_DIR: /data/nas/export
               PAPERLESS_DATA_DIR: /data/local/data
               PAPERLESS_MEDIA_ROOT: /data/local/media
+              # File naming
+              PAPERLESS_FILENAME_FORMAT: "{{ correspondent }}/{{ created_year }}-{{ title }}"
+              PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
               # Consumer
               PAPERLESS_CONSUMER_POLLING_INTERVAL: "60"
               PAPERLESS_CONSUMER_RECURSIVE: "true"

--- a/apps/media/paperless/app/helm-release.yaml
+++ b/apps/media/paperless/app/helm-release.yaml
@@ -75,7 +75,8 @@ spec:
               PAPERLESS_DATA_DIR: /data/local/data
               PAPERLESS_MEDIA_ROOT: /data/local/media
               # File naming
-              PAPERLESS_FILENAME_FORMAT: "{{ correspondent }}/{{ created_year }}-{{ title }}"
+              PAPERLESS_FILENAME_FORMAT: >-
+                {{ "{{" }} correspondent {{ "}}" }}/{{ "{{" }} created_year {{ "}}" }}-{{ "{{" }} title {{ "}}" }}
               PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
               # Consumer
               PAPERLESS_CONSUMER_POLLING_INTERVAL: "60"


### PR DESCRIPTION
## Summary
- Set `PAPERLESS_FILENAME_FORMAT` to `{{ correspondent }}/{{ created_year }}-{{ title }}` so documents in the media root are organized human-readably instead of paperless's default opaque ID-based naming (`0000123.pdf`).
- Sets `PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"` so empty placeholders (e.g. no correspondent set) don't leave literal `none` segments in the path.

This reduces (but doesn't eliminate) storage lock-in: the archive still lives under paperless's managed PVC, but the internal layout is now legible/exportable on its own rather than being a flat ID-keyed dump.

## Follow-up (not run automatically)
Existing consumed documents won't retroactively rename themselves. After this deploys, run the `document renamer` management command once to reorganize already-consumed documents into the new layout:
\`\`\`bash
kubectl exec -n media deploy/paperless -c app -- document_renamer
\`\`\`

## Test plan
- [ ] Confirm HelmRelease reconciles cleanly and the `paperless` pod restarts without errors
- [ ] Consume a new test document and verify it lands at the expected `correspondent/year-title` path
- [ ] Run `document_renamer` and spot-check a few existing documents moved to the new layout